### PR TITLE
fix(POS-1168): replace features unsupported by TS version in checkout-cdn to enable checkout-cdn build

### DIFF
--- a/src/dynamic-checkout/config/theme.ts
+++ b/src/dynamic-checkout/config/theme.ts
@@ -11,8 +11,11 @@ module ProcessOut {
     payButtonTextColor?: string;
 
     constructor(config?: DynamicCheckoutThemeType) {
-      this.payButtonColor = config?.payButtonColor;
-      this.payButtonTextColor = config?.payButtonTextColor;
+      if (!config) {
+        return;
+      }
+      this.payButtonColor = config.payButtonColor;
+      this.payButtonTextColor = config.payButtonTextColor;
     }
 
     public getConfig(): DynamicCheckoutThemeType {

--- a/src/dynamic-checkout/payment-methods/apm.ts
+++ b/src/dynamic-checkout/payment-methods/apm.ts
@@ -143,12 +143,12 @@ module ProcessOut {
 
       HTMLElements.appendChildren(childrenWrapper, children);
 
-      if (this.theme?.payButtonColor) {
-        payButton.style.backgroundColor = this.theme?.payButtonColor;
+      if (this.theme && this.theme.payButtonColor) {
+        payButton.style.backgroundColor = this.theme.payButtonColor;
       }
 
-      if (this.theme?.payButtonTextColor) {
-        payButton.style.color = this.theme?.payButtonTextColor;
+      if (this.theme && this.theme.payButtonTextColor) {
+        payButton.style.color = this.theme.payButtonTextColor;
       }
 
       payButton.addEventListener("click", () => {

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -221,12 +221,12 @@ module ProcessOut {
         },
       ]);
 
-      if (this.theme?.payButtonColor) {
-        payButton.style.backgroundColor = this.theme?.payButtonColor;
+      if (this.theme && this.theme.payButtonColor) {
+        payButton.style.backgroundColor = this.theme.payButtonColor;
       }
 
-      if (this.theme?.payButtonTextColor) {
-        payButton.style.color = this.theme?.payButtonTextColor;
+      if (this.theme && this.theme.payButtonTextColor) {
+        payButton.style.color = this.theme.payButtonTextColor;
       }
 
       HTMLElements.appendChildren(saveForFutureWrapper, [
@@ -543,12 +543,21 @@ module ProcessOut {
       countryInput.addEventListener("change", (e) => {
         const selectElement = e.target as HTMLSelectElement;
 
-        billingAddressFieldsWrapper.replaceChildren(
+        this.replaceChildren(
+          billingAddressFieldsWrapper,
           ...this.getBillingAddressField(selectElement.value)
         );
       });
 
       return countryInput;
+    }
+
+    private replaceChildren(parent: HTMLElement, ...newChildren: HTMLElement[]): void {
+      while (parent.firstChild) {
+        parent.removeChild(parent.firstChild);
+      }
+
+      newChildren.forEach(child => parent.appendChild(child));
     }
 
     private getBillingAddressField(country: string) {

--- a/src/dynamic-checkout/payment-methods/native-apm.ts
+++ b/src/dynamic-checkout/payment-methods/native-apm.ts
@@ -33,11 +33,13 @@ module ProcessOut {
         returnUrl: invoiceDetails.return_url,
       });
 
+      const backgroundColor = this.theme && this.theme.payButtonColor ? this.theme.payButtonColor : "#242C38";
+      const color = this.theme && this.theme.payButtonTextColor ? this.theme.payButtonTextColor : "white";
       this.nativeApmInstance.setTheme({
         buttons: {
           default: {
-            backgroundColor: this.theme?.payButtonColor || "#242C38",
-            color: this.theme?.payButtonTextColor || "white",
+            backgroundColor: backgroundColor,
+            color: color,
           },
         },
       });

--- a/src/dynamic-checkout/payment-methods/saved-apm.ts
+++ b/src/dynamic-checkout/payment-methods/saved-apm.ts
@@ -42,12 +42,12 @@ module ProcessOut {
         },
       ]);
 
-      if (this.theme?.payButtonColor) {
-        payButton.style.backgroundColor = this.theme?.payButtonColor;
+      if (this.theme && this.theme.payButtonColor) {
+        payButton.style.backgroundColor = this.theme.payButtonColor;
       }
 
-      if (this.theme?.payButtonTextColor) {
-        payButton.style.color = this.theme?.payButtonTextColor;
+      if (this.theme && this.theme.payButtonTextColor) {
+        payButton.style.color = this.theme.payButtonTextColor;
       }
 
       HTMLElements.appendChildren(wrapper, [payButton]);

--- a/src/dynamic-checkout/payment-methods/saved-card.ts
+++ b/src/dynamic-checkout/payment-methods/saved-card.ts
@@ -43,12 +43,12 @@ module ProcessOut {
         },
       ]);
 
-      if (this.theme?.payButtonColor) {
-        payButton.style.backgroundColor = this.theme?.payButtonColor;
+      if (this.theme && this.theme.payButtonColor) {
+        payButton.style.backgroundColor = this.theme.payButtonColor;
       }
 
-      if (this.theme?.payButtonTextColor) {
-        payButton.style.color = this.theme?.payButtonTextColor;
+      if (this.theme && this.theme.payButtonTextColor) {
+        payButton.style.color = this.theme.payButtonTextColor;
       }
 
       HTMLElements.appendChildren(wrapper, [payButton]);


### PR DESCRIPTION
## Description
processout.js has newer TS version than checkout-cdn. But checkout-cdn is used to build and deploy processout.js. Thus, processout.js must use features supported by checkout-cdn's TS version only.

Checkout-cdn builds [keep failing at the moment](https://github.com/processout/checkout-cdn/actions/runs/11458022430/job/31879543492?pr=230#step:5:651), because checkout-cdn's TS version does not support optional chaining `?.` operator or `HTMLElement.replaceChildren()` function.

## Solution
Replace optional chaining with explicit `if` guards and write our own util function for replacing HTMLElement children.

## Notes


## Jira Issue
* [POS-1168](https://checkout.atlassian.net/browse/POS-1168)


[POS-1168]: https://checkout.atlassian.net/browse/POS-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ