### PR TITLE
chore: dynamic checkout - use apple pay and google sdk from our domain

### DIFF
--- a/src/dynamic-checkout/config/external-libraries.ts
+++ b/src/dynamic-checkout/config/external-libraries.ts
@@ -1,6 +1,5 @@
 module ProcessOut {
-  export const applePaySdkUrl =
-    "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+  export const applePaySdkUrl = "https://js.processout.com/js/libraries/apple-pay-sdk.js"
 
-  export const googlePaySdkUrl = "https://pay.google.com/gp/p/js/pay.js";
+  export const googlePaySdkUrl = "https://js.processout.com/js/libraries/google-pay-sdk.js"
 }


### PR DESCRIPTION
<!--- Ensure the title above contains the Jira issue name e.g PROCESS0UT-1 -->

## Description
I moved Apple Pay JS SDK and Google Pay JS SDK used in Dynamic Checkout to be used under our domain, due to new PCI changes. This PR just changes URLs

## Solution
<!--- Describe the solution/fix implemented in this PR. -->

## Demo
<!--- If applicable, provide a demo of the solution/fix implemented in this PR. -->

## Notes
<!--- Include any extra notes you may want the reviewer to know -->

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
