### PR TITLE
feat: dc - load assets per environment

### DIFF
--- a/src/dynamic-checkout/clients/google-pay.ts
+++ b/src/dynamic-checkout/clients/google-pay.ts
@@ -4,6 +4,7 @@ module ProcessOut {
   export class GooglePayClient {
     googleClient: any;
     processOutInstance: ProcessOut;
+    paymentConfig: DynamicCheckoutPaymentConfigType;
     isReadyToPayRequest: {
       apiVersion: number;
       apiVersionMinor: number;
@@ -50,8 +51,9 @@ module ProcessOut {
       };
     };
 
-    constructor(processOutInstance: ProcessOut) {
+    constructor(processOutInstance: ProcessOut, paymentConfig: DynamicCheckoutPaymentConfigType) {
       this.processOutInstance = processOutInstance;
+      this.paymentConfig = paymentConfig;
     }
 
     public loadButton(
@@ -123,7 +125,7 @@ module ProcessOut {
           processOutInstance.tokenize(
             paymentToken,
             {},
-            function (token) {
+            (token) => {
               DynamicCheckoutEventsUtils.dispatchTokenizePaymentSuccessEvent(
                 token
               );
@@ -134,9 +136,9 @@ module ProcessOut {
                 {
                   authorize_only: !this.paymentConfig.capturePayments,
                 },
-                function (invoiceId) {
-                  this.resetContainerHtml().appendChild(
-                    new DynamicCheckoutPaymentSuccessView(this.paymentConfig)
+                (invoiceId) => {
+                  getViewContainer().appendChild(
+                    new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
                       .element
                   );
                   DynamicCheckoutEventsUtils.dispatchPaymentSuccessEvent({
@@ -144,18 +146,18 @@ module ProcessOut {
                     returnUrl: this.paymentConfig.invoiceDetails.return_url,
                   });
                 },
-                function (error) {
-                  this.resetContainerHtml().appendChild(
-                    new DynamicCheckoutPaymentErrorView(this.paymentConfig)
-                      .element
-                  );
+                (error) => {
+                  getViewContainer().appendChild(
+                    new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
+                      .element,
+                  )
                   DynamicCheckoutEventsUtils.dispatchPaymentErrorEvent(error);
                 }
               );
             },
-            function (err) {
-              this.resetContainerHtml().appendChild(
-                new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+            (err) => {
+              getViewContainer().appendChild(
+                new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig).element
               );
               DynamicCheckoutEventsUtils.dispatchTokenizePaymentErrorEvent({
                 message: `Tokenize payment error: ${JSON.stringify(

--- a/src/dynamic-checkout/config/assets.ts
+++ b/src/dynamic-checkout/config/assets.ts
@@ -1,15 +1,14 @@
 module ProcessOut {
   export const CARD_SCHEMES_ASSETS = {
-    visa: "https://js.processout.com/images/schemes/rectangle/visa.svg",
-    mastercard:
-      "https://js.processout.com/images/schemes/rectangle/mastercard.svg",
-    amex: "https://js.processout.com/images/schemes/rectangle/americanexpress.svg",
-    unionpay: "https://js.processout.com/images/schemes/rectangle/unionpay.svg",
+    visa: "/images/schemes/rectangle/visa.svg",
+    mastercard: "/images/schemes/rectangle/mastercard.svg",
+    amex: "/images/schemes/rectangle/americanexpress.svg",
+    unionpay: "/images/schemes/rectangle/unionpay.svg",
   };
 
   export const PAYMENT_SUCCESS_IMAGE_ASSET =
-    "https://js.processout.com/images/dynamic-checkout-assets/payment-success.svg";
+    "/images/dynamic-checkout-assets/payment-success.svg";
 
   export const PAYMENT_ERROR_IMAGE_ASSET =
-    "https://js.processout.com/images/dynamic-checkout-assets/payment-error.svg";
+    "/images/dynamic-checkout-assets/payment-error.svg";
 }

--- a/src/dynamic-checkout/dynamic-checkout.ts
+++ b/src/dynamic-checkout/dynamic-checkout.ts
@@ -83,7 +83,7 @@ module ProcessOut {
     private onGetInvoiceSuccess(data: any) {
       if (!data.success) {
         this.loadView(
-          new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+          new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig).element
         );
 
         return DynamicCheckoutEventsUtils.dispatchInvoiceFetchingErrorEvent(
@@ -94,6 +94,7 @@ module ProcessOut {
       if (!data.invoice.payment_methods) {
         this.loadView(
           new DynamicCheckoutPaymentErrorView(
+            this.processOutInstance,
             this.paymentConfig,
             Translations.getText(
               "payment-error-generic-message",
@@ -112,6 +113,7 @@ module ProcessOut {
       if (data.invoice.transaction.status !== "waiting") {
         this.loadView(
           new DynamicCheckoutPaymentErrorView(
+            this.processOutInstance,
             this.paymentConfig,
             Translations.getText(
               "payment-error-generic-message",
@@ -148,7 +150,7 @@ module ProcessOut {
       DynamicCheckoutEventsUtils.dispatchInvoiceFetchingErrorEvent(errorData);
 
       this.loadView(
-        new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+        new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig).element
       );
     }
 

--- a/src/dynamic-checkout/payment-methods/apm.ts
+++ b/src/dynamic-checkout/payment-methods/apm.ts
@@ -91,7 +91,7 @@ module ProcessOut {
             cardPaymentOptions,
             (invoiceId) => {
               this.resetContainerHtml().appendChild(
-                new DynamicCheckoutPaymentSuccessView(this.paymentConfig)
+                new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
                   .element
               );
 
@@ -99,7 +99,7 @@ module ProcessOut {
             },
             (error) => {
               this.resetContainerHtml().appendChild(
-                new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+                new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig).element
               );
 
               DynamicCheckoutEventsUtils.dispatchPaymentErrorEvent(error);
@@ -138,7 +138,7 @@ module ProcessOut {
                 options,
                 (invoiceId) => {
                   this.resetContainerHtml().appendChild(
-                    new DynamicCheckoutPaymentSuccessView(this.paymentConfig)
+                    new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
                       .element
                   );
 
@@ -148,7 +148,7 @@ module ProcessOut {
                 },
                 (error) => {
                   this.resetContainerHtml().appendChild(
-                    new DynamicCheckoutPaymentErrorView(this.paymentConfig)
+                    new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
                       .element
                   );
 
@@ -163,7 +163,7 @@ module ProcessOut {
         },
         (error) => {
           this.resetContainerHtml().appendChild(
-            new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+            new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig).element
           );
 
           DynamicCheckoutEventsUtils.dispatchPaymentErrorEvent(error);

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -27,7 +27,7 @@ module ProcessOut {
           tagName: "img",
           classNames: ["dco-card-scheme-logo"],
           attributes: {
-            src: CARD_SCHEMES_ASSETS[schema],
+            src: procesoutInstance.endpoint("js", CARD_SCHEMES_ASSETS[schema]),
           },
         });
 
@@ -117,7 +117,7 @@ module ProcessOut {
 
     private handleCardPaymentSuccess(invoiceId: string) {
       this.resetContainerHtml().appendChild(
-        new DynamicCheckoutPaymentSuccessView(this.paymentConfig).element
+        new DynamicCheckoutPaymentSuccessView(this.procesoutInstance, this.paymentConfig).element
       );
       DynamicCheckoutEventsUtils.dispatchPaymentSuccessEvent({
         invoiceId,
@@ -127,7 +127,7 @@ module ProcessOut {
 
     private handleCardPaymentError(error) {
       this.resetContainerHtml().appendChild(
-        new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+        new DynamicCheckoutPaymentErrorView(this.procesoutInstance, this.paymentConfig).element
       );
       DynamicCheckoutEventsUtils.dispatchPaymentErrorEvent(error);
     }

--- a/src/dynamic-checkout/payment-methods/google-pay.ts
+++ b/src/dynamic-checkout/payment-methods/google-pay.ts
@@ -7,10 +7,11 @@ module ProcessOut {
 
     constructor(
       processOutInstance: ProcessOut,
+      paymentConfig: DynamicCheckoutPaymentConfigType,
       invoiceData: Invoice,
       resetContainerHtml: () => HTMLElement
     ) {
-      this.googleClient = new GooglePayClient(processOutInstance);
+      this.googleClient = new GooglePayClient(processOutInstance, paymentConfig);
 
       this.element = this.getGooglePayButtonElement();
 

--- a/src/dynamic-checkout/payment-methods/native-apm.ts
+++ b/src/dynamic-checkout/payment-methods/native-apm.ts
@@ -7,6 +7,7 @@ module ProcessOut {
     private isMounted: boolean;
     private theme: DynamicCheckoutThemeType;
     private resetContainerHtml: () => HTMLElement;
+    private processOutInstance: ProcessOut;
 
     constructor(
       processOutInstance: ProcessOut,
@@ -21,13 +22,14 @@ module ProcessOut {
       super(display.name, display.logo.dark_url.vector);
 
       this.paymentConfig = paymentConfig;
+      this.processOutInstance = processOutInstance;
       this.resetContainerHtml = resetContainerHtml;
       this.theme = theme;
 
       const wrapper = this.getNativeApmWrapper();
       super.appendChildren(wrapper);
 
-      this.nativeApmInstance = processOutInstance.setupNativeApm({
+      this.nativeApmInstance = this.processOutInstance.setupNativeApm({
         invoiceId,
         gatewayConfigurationId: apm.gateway_configuration_id,
         returnUrl: invoiceDetails.return_url,
@@ -65,7 +67,7 @@ module ProcessOut {
 
       window.addEventListener(NATIVE_APM_EVENTS.PAYMENT_SUCCESS, (e) => {
         this.resetContainerHtml().appendChild(
-          new DynamicCheckoutPaymentSuccessView(this.paymentConfig).element
+          new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig).element
         );
 
         DynamicCheckoutEventsUtils.dispatchPaymentSuccessEvent({
@@ -76,7 +78,7 @@ module ProcessOut {
 
       window.addEventListener(NATIVE_APM_EVENTS.PAYMENT_ERROR, (e) => {
         this.resetContainerHtml().appendChild(
-          new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+          new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig).element
         );
 
         DynamicCheckoutEventsUtils.dispatchPaymentErrorEvent(e);

--- a/src/dynamic-checkout/payment-methods/saved-apm.ts
+++ b/src/dynamic-checkout/payment-methods/saved-apm.ts
@@ -103,7 +103,7 @@ module ProcessOut {
               cardPaymentOptions,
               (invoiceId) => {
                 this.resetContainerHtml().appendChild(
-                  new DynamicCheckoutPaymentSuccessView(this.paymentConfig)
+                  new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
                     .element
                 );
 
@@ -113,7 +113,7 @@ module ProcessOut {
               },
               (error) => {
                 this.resetContainerHtml().appendChild(
-                  new DynamicCheckoutPaymentErrorView(this.paymentConfig)
+                  new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
                     .element
                 );
 
@@ -139,7 +139,7 @@ module ProcessOut {
 
     private handlePaymentSuccess(invoiceId: string) {
       this.resetContainerHtml().appendChild(
-        new DynamicCheckoutPaymentSuccessView(this.paymentConfig).element
+        new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig).element
       );
       DynamicCheckoutEventsUtils.dispatchPaymentSuccessEvent({
         invoiceId,
@@ -149,7 +149,7 @@ module ProcessOut {
 
     private handlePaymentError(error) {
       this.resetContainerHtml().appendChild(
-        new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+        new DynamicCheckoutPaymentErrorView(this.processOutInstance,this.paymentConfig).element
       );
       DynamicCheckoutEventsUtils.dispatchPaymentErrorEvent(error);
     }

--- a/src/dynamic-checkout/payment-methods/saved-card.ts
+++ b/src/dynamic-checkout/payment-methods/saved-card.ts
@@ -89,7 +89,7 @@ module ProcessOut {
 
     private handlePaymentSuccess(invoiceId: string) {
       this.resetContainerHtml().appendChild(
-        new DynamicCheckoutPaymentSuccessView(this.paymentConfig).element
+        new DynamicCheckoutPaymentSuccessView(this.processOutInstance,this.paymentConfig).element
       );
       DynamicCheckoutEventsUtils.dispatchPaymentSuccessEvent({
         invoiceId,
@@ -99,7 +99,7 @@ module ProcessOut {
 
     private handlePaymentError(error) {
       this.resetContainerHtml().appendChild(
-        new DynamicCheckoutPaymentErrorView(this.paymentConfig).element
+        new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig).element
       );
       DynamicCheckoutEventsUtils.dispatchPaymentErrorEvent(error);
     }

--- a/src/dynamic-checkout/views/payment-error.ts
+++ b/src/dynamic-checkout/views/payment-error.ts
@@ -5,6 +5,7 @@ module ProcessOut {
     public element: Element;
 
     constructor(
+      processOutInstance: ProcessOut,
       paymentConfig: DynamicCheckoutPaymentConfigType,
       errorMessage?: string
     ) {
@@ -17,7 +18,7 @@ module ProcessOut {
           tagName: "img",
           classNames: ["dco-card-payment-success-image"],
           attributes: {
-            src: PAYMENT_ERROR_IMAGE_ASSET,
+            src: processOutInstance.endpoint("js", PAYMENT_ERROR_IMAGE_ASSET),
           },
         },
         {

--- a/src/dynamic-checkout/views/payment-methods.ts
+++ b/src/dynamic-checkout/views/payment-methods.ts
@@ -192,6 +192,7 @@ module ProcessOut {
             case "googlepay":
               const googlePayPaymentMethod = new GooglePayPaymentMethod(
                 this.processOutInstance,
+                this.paymentConfig,
                 this.paymentConfig.invoiceDetails,
                 this.resetContainerHtml.bind(this)
               );

--- a/src/dynamic-checkout/views/payment-success.ts
+++ b/src/dynamic-checkout/views/payment-success.ts
@@ -4,7 +4,7 @@ module ProcessOut {
   export class DynamicCheckoutPaymentSuccessView {
     public element: Element;
 
-    constructor(paymentConfig: DynamicCheckoutPaymentConfigType) {
+    constructor(processOutInstance: ProcessOut, paymentConfig: DynamicCheckoutPaymentConfigType) {
       const [element, image, message] = HTMLElements.createMultipleElements([
         {
           tagName: "div",
@@ -14,7 +14,7 @@ module ProcessOut {
           tagName: "img",
           classNames: ["dco-card-payment-success-image"],
           attributes: {
-            src: PAYMENT_SUCCESS_IMAGE_ASSET,
+            src: processOutInstance.endpoint("js", PAYMENT_SUCCESS_IMAGE_ASSET),
           },
         },
         {

--- a/src/nativeapm/nativeapm.ts
+++ b/src/nativeapm/nativeapm.ts
@@ -533,8 +533,7 @@ module ProcessOut {
      */
     private loadMarkdownLibrary() {
       const markdownScript = document.createElement("script");
-      markdownScript.src =
-        "https://js.processout.com/js/libraries/showdown.min.js";
+      markdownScript.src = this.processOutInstance.endpoint("js", "/js/libraries/showdown.min.js")
       markdownScript.onload = () => {
         this.markdownLibraryInstance =
           window.globalThis && window.globalThis.showdown
@@ -546,7 +545,7 @@ module ProcessOut {
 
     private loadQrCodesLibrary() {
       const qrCodeScript = document.createElement("script");
-      qrCodeScript.src = "https://js.processout.com/js/libraries/qrcode.min.js";
+      qrCodeScript.src = this.processOutInstance.endpoint("js", "/js/libraries/qrcode.min.js")
       document.head.appendChild(qrCodeScript);
     }
   }


### PR DESCRIPTION
<!--- Ensure the title above contains the Jira issue name e.g PROCESS0UT-1 -->

## Description
This is purely Dynamic Checkout change - it shouldn't affect regular card payments. We need this PR because of recent PCI changes and new HPP changes

## Solution
This PR changes how we're loading images/js scripts inside Dynamic Checkout. Now it takes host based on the environment we're using ProcessOut.js so:
- if we're on staging it will load scripts from js.processout.ninja
- it we're on production it will load scripts from js.processout.com

Two additional things are fixes for Apple Pay and Google Pay

## Demo
<!--- If applicable, provide a demo of the solution/fix implemented in this PR. -->

## Notes
<!--- Include any extra notes you may want the reviewer to know -->

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
