### PR TITLE
fix(ad-hoc): cannot set properties of null (setting 'namespace')

### DIFF
--- a/src/processout/message.ts
+++ b/src/processout/message.ts
@@ -26,8 +26,11 @@ module ProcessOut {
 
         public static parseEvent(e: MessageEvent): Message {
             try {
-                var d = JSON.parse(e.data);
-                return <Message>d;
+              if (e && e.data) {
+                const d = JSON.parse(e.data);
+                return d ? <Message>d : new Message();
+              }
+              return new Message();
             } catch (e) {
                 return new Message();
             }


### PR DESCRIPTION
## Description
We received an inquiry from Hostinger about the `TypeError: Cannot set properties of null (setting 'namespace')` error in the console when 3DS modal should be displayed (and it is not).
The error column let us narrow it down to issue with parsing window message, when accessing `data.namespace` field.

Slack thread for reference: https://processout.slack.com/archives/C03RLJH717U/p1742471599026289

## Solution
Add safeguards for window Message to be defined when parsing and returning the result.

## Demo


## Checklist

- [ ] I bumped the version of the project using `yarn bump-version`
- [ ] I have checked the code for any potential issues
- [ ] I tested my changes in the browser

## Notes


## Jira Issue
