### PR TITLE
ci(version-bump): add check if package.json version is changed in the PR

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,6 +1,6 @@
 name: Build, lint and test
 
-on: [push]
+on: [ push ]
 
 jobs:
   test:
@@ -19,6 +19,39 @@ jobs:
           key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('./yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-build-cache-node-modules-
+
+      - name: Check package.json version changed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const diff = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: context.payload.before,
+              head: context.payload.after,
+            });
+
+            if (!diff.data.files) {
+              core.info('No files changed in this Pull Request.');
+              return;
+            }
+            const packageJsonDiff = diff.data.files.find(file => file.filename === 'package.json');
+            if (!packageJsonDiff) {
+              core.setFailed('package.json file has not been modified in this Pull Request. Bump the version using `yarn bump` command.');
+              return;
+            }
+
+            const versionChangeRegex = /"version":\s*"(.+)"/;
+            const oldVersionMatch = versionChangeRegex.exec(packageJsonDiff.patch.split('\n').find(line => line.startsWith('-')));
+            const newVersionMatch = versionChangeRegex.exec(packageJsonDiff.patch.split('\n').find(line => line.startsWith('+')));
+
+
+            if (!oldVersionMatch || !newVersionMatch || oldVersionMatch[1] === newVersionMatch[1]) {
+              core.setFailed('The version in package.json has not been modified. Bump the version using `yarn bump` command.');
+              return;
+            }
+
+            core.info('Version check passed.');
 
       - name: Install dependencies
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -20,9 +20,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-cache-node-modules-
 
+      - name: Configure git for private modules
+        env:
+          PO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PO_GITHUB_USER: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          git config \
+           --global url."https://${PO_GITHUB_USER}:${PO_GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
+
       - name: Check package.json version changed
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const diff = await github.rest.repos.compareCommits({
               owner: context.repo.owner,
@@ -37,7 +47,7 @@ jobs:
             }
             const packageJsonDiff = diff.data.files.find(file => file.filename === 'package.json');
             if (!packageJsonDiff) {
-              core.setFailed('package.json file has not been modified in this Pull Request. Bump the version using `yarn bump` command.');
+              core.setFailed('package.json file has not been modified in this Pull Request. Bump the version using `yarn bump-version` command.');
               return;
             }
 
@@ -47,7 +57,7 @@ jobs:
 
 
             if (!oldVersionMatch || !newVersionMatch || oldVersionMatch[1] === newVersionMatch[1]) {
-              core.setFailed('The version in package.json has not been modified. Bump the version using `yarn bump` command.');
+              core.setFailed('The version in package.json has not been modified. Bump the version using `yarn bump-version` command.');
               return;
             }
 

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,6 +1,6 @@
 name: Build, lint and test
 
-on: [ push ]
+on: [push]
 
 jobs:
   test:
@@ -19,49 +19,6 @@ jobs:
           key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('./yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-build-cache-node-modules-
-
-      - name: Configure git for private modules
-        env:
-          PO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PO_GITHUB_USER: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          git config \
-           --global url."https://${PO_GITHUB_USER}:${PO_GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
-
-      - name: Check package.json version changed
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const diff = await github.rest.repos.compareCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              base: context.payload.before,
-              head: context.payload.after,
-            });
-
-            if (!diff.data.files) {
-              core.info('No files changed in this Pull Request.');
-              return;
-            }
-            const packageJsonDiff = diff.data.files.find(file => file.filename === 'package.json');
-            if (!packageJsonDiff) {
-              core.setFailed('package.json file has not been modified in this Pull Request. Bump the version using `yarn bump-version` command.');
-              return;
-            }
-
-            const versionChangeRegex = /"version":\s*"(.+)"/;
-            const oldVersionMatch = versionChangeRegex.exec(packageJsonDiff.patch.split('\n').find(line => line.startsWith('-')));
-            const newVersionMatch = versionChangeRegex.exec(packageJsonDiff.patch.split('\n').find(line => line.startsWith('+')));
-
-
-            if (!oldVersionMatch || !newVersionMatch || oldVersionMatch[1] === newVersionMatch[1]) {
-              core.setFailed('The version in package.json has not been modified. Bump the version using `yarn bump-version` command.');
-              return;
-            }
-
-            core.info('Version check passed.');
 
       - name: Install dependencies
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,16 @@
+name: Check version bumped
+
+on: [ pull_request ]
+
+jobs:
+  check-version-bumped:
+    name: "Check version bumped"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const script = require('./scripts/check-version-bumped.js');
+            await script({core, github, context});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.0.1"  ,
+  "version": "1.0.2",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.0.1",
+  "version": "1.0.1"  ,
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/scripts/check-version-bumped.js
+++ b/scripts/check-version-bumped.js
@@ -1,0 +1,43 @@
+/* eslint-disable */
+
+module.exports = async ({core, github, context}) => {
+  if (context.eventName !== 'pull_request') {
+    core.info('This action is only applicable for pull_request event.');
+    return;
+  }
+
+  const diff = await github.rest.repos.compareCommits({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    base: context.payload.pull_request.base.sha,
+    head: context.payload.pull_request.head.sha,
+  });
+
+  if (!diff.data.files) {
+    core.info('No files changed in this Pull Request.');
+    return;
+  }
+  const packageJsonDiff = diff.data.files.find(file => file.filename === 'package.json');
+  if (!packageJsonDiff) {
+    core.setFailed('package.json file has not been modified in this Pull Request. Bump the version using `yarn bump-version` command.');
+    return;
+  }
+
+  const versionChangeRegex = /"version":\s*"(.+)"/;
+  const oldVersionMatch = versionChangeRegex.exec(
+    packageJsonDiff.patch.split('\n')
+      .find(line => line.startsWith('-'))
+  );
+  const newVersionMatch = versionChangeRegex.exec(
+    packageJsonDiff.patch.split('\n')
+      .find(line => line.startsWith('+'))
+  );
+
+
+  if (!oldVersionMatch || !newVersionMatch || oldVersionMatch[1] === newVersionMatch[1]) {
+    core.setFailed('The version in package.json has not been modified. Bump the version using `yarn bump-version` command.');
+    return;
+  }
+
+  core.info('Version check passed.');
+}


### PR DESCRIPTION
## Description
The last PR we missed the `package.json` version being bumped due to the fact that after other change automatic rebase, we had no conflicts and the other version upgraded `package.json` version to the same, we wanted to in this commit.

## Solution
1. Bump the version to 1.0.2.
2. Add GHA step to check `package.json` version is changed.

## Demo

## Checklist

- [x] I bumped the version of the project using `yarn bump-version`
- [x] I have checked the code for any potential issues
- [x] I tested my changes in the browser

## Notes

## Jira Issue

