### PR TITLE
feat(POS-1338): Implement ActionHandler instance binding (remedy cross-contamination)

### DIFF
--- a/src/processout/actionhandler.ts
+++ b/src/processout/actionhandler.ts
@@ -194,10 +194,16 @@ module ProcessOut {
         protected options: ActionHandlerOptions;
 
         /**
-         * listenerCount is the number of listener that were set
-         * @type {number}
+         * Action handler static counter to track events
+         * @var {number}
          */
-        protected static listenerCount = 0;
+        protected static listenerCount: number = 0;
+                
+        /**
+         * Unique identifier for this ActionHandler instance
+         * @var {string}
+         */
+        protected instanceUID: string;
 
         /**
          * newWindowName is the name of the new windows created by the
@@ -216,6 +222,11 @@ module ProcessOut {
             this.options  = options;
 
             if (!this.options) this.options = new ActionHandlerOptions();
+
+            // Generate unique identifier for this instance to prevent cross-contamination
+            this.instanceUID = `action_${Math.random().toString(36).substring(7)}`;
+            
+            // Note: setResourceID() should be invoked when calling specific action methods
 
             // We need to create the wrapper beforehand
             if (this.options.flow == ActionFlow.IFrame) {
@@ -466,6 +477,11 @@ module ProcessOut {
                 if (data.namespace != Message.checkoutNamespace)
                     return;
 
+                // Validate the message is intended for this specific ActionHandler instance to prevent cross-contamination
+                if (data.frameID && data.frameID !== this.instanceUID) {
+                    return; // Message is for a different ActionHandler instance
+                }
+
                 // Not the latest listener anymore
                 if (ActionHandler.listenerCount != cur) {
                     // Reset the timer if it hasn't been done already
@@ -549,6 +565,24 @@ module ProcessOut {
          */
         public isCanceled(): boolean {
             return this.canceled;
+        }
+
+        /**
+         * Set the resource ID for this ActionHandler instance
+         * @param {string} resourceID
+         * @return {void}
+         */
+        public setResourceID(resourceID: string): void {
+            this.resourceID = resourceID;
+        }
+
+        /**
+         * Get the unique instance ID for this ActionHandler
+         * This can be used by checkout pages to include in postMessage responses
+         * @return {string}
+         */
+        public getInstanceUID(): string {
+            return this.instanceUID;
         }
 
     }


### PR DESCRIPTION
## Description
Implement safeguards similar to these in `CardField` into `ActionHandler` to prevent race conditions and cross-contamination between multiple tabs/instances. Here's what has been added:

**🔧 Key Changes Made:**
- Instance-Specific Unique Identifiers (`instanceUID`)
- `data.frameID` validation against `this.instanceUID`
- New Public Methods for Resource Management
  - `setResourceID()`; _informational for now_
  - `getInstanceUID() `; 

**🛡️ Security Improvements:**
- Instance Isolation: Each ActionHandler now has a unique identifier that prevents messages from other instances being processed
- Resource ID Tracking: Added capability to track which resource (invoice) an ActionHandler is associated with
- Frame ID Validation: Messages from the `processout.checkout` namespace are only processed if they have the correct `frameID` matching the `instanceUID`

**📋 Next steps:**
To fully implement this solution, we have to update the checkout pages' `postMessage` responses with the `frameID`


## Solution
<!--- Describe the solution/fix implemented in this PR. -->

## Demo
<!--- If applicable, provide a demo of the solution/fix implemented in this PR. -->

## Checklist

- [ ] I bumped the version of the project using `yarn bump-version`
- [ ] I have checked the code for any potential issues
- [ ] I tested my changes in the browser

## Jira Issue
https://checkout.atlassian.net/browse/POS-1338
