### PR TITLE
POCD-348 fix: add success copy fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/apm/views/Success.ts
+++ b/src/apm/views/Success.ts
@@ -76,6 +76,9 @@ module ProcessOut {
         }, this.timeout)
       }
 
+      const title = this.props.config.invoice ? 'Payment approved!' : "You're all set!"
+      const description = this.props.config.invoice ? `You paid ${formatCurrency(this.props.config.invoice.amount, this.props.config.invoice.currency)}` : null
+
       return Main({ 
         config: this.props.config, 
         className: "success-page", 
@@ -95,8 +98,8 @@ module ProcessOut {
             )
           ),
           div({ className: "header-container" },
-            Header({ tag: 'h2' }, 'Payment approved!'),
-            SubHeader({ tag: 'h3' }, `You paid ${formatCurrency(this.props.config.invoice.amount, this.props.config.invoice.currency)}`),
+            Header({ tag: 'h2' }, title),
+            description && SubHeader({ tag: 'h3' }, description),
           ),
         ),
         ...(this.props.elements ? renderElements(this.props.elements) : []),


### PR DESCRIPTION
## Description
This PR enhances the APM success page to provide more appropriate messaging based on whether an invoice is present in the configuration. Currently, the success page always shows "Payment approved!" and payment amount, which may not be appropriate for all APM flows.

## Solution
- **Dynamic title**: Shows "Payment approved!" when invoice is present, "You're all set!" when no invoice
- **Conditional description**: Only shows payment amount when invoice is present
- **Improved UX**: Provides more appropriate messaging for different APM scenarios

### Changes Made:
- Updated `src/apm/views/Success.ts` to conditionally render title and description
- Added logic to check for invoice presence in configuration
- Maintained existing functionality while adding flexibility for different APM flows

## Demo
The success page now displays:
- **With invoice**: "Payment approved!" + payment amount
- **Without invoice**: "You're all set!" (no amount shown)

## Checklist

- [x] I bumped the version of the project using `yarn bump-version`
- [x] I have checked the code for any potential issues
- [x] I tested my changes in the browser

## Notes
This change improves the user experience by providing contextually appropriate messaging for different APM payment flows, particularly useful for flows that don't involve a traditional invoice.

## Jira Issue
POCD-348