### PR TITLE
chore: provide more scalable interface for dynamic checkout

### DIFF
--- a/examples/dynamic-checkout-init/index.html
+++ b/examples/dynamic-checkout-init/index.html
@@ -1,8 +1,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
-    <title>ProcessOut.js Dynamic Checkout</title>
-    <link rel="stylesheet" href="styles.css" />
+    <title>ProcessOut.js Dynamic Checkout (initDynamicCheckout)</title>
+    <link rel="stylesheet" href="../dynamic-checkout/styles.css" />
   </head>
   <body>
     <main class="example-layout">
@@ -148,7 +148,7 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
 
     <script src="../../dist/processout.js" crossorigin="anonymous"></script>
     <script>
-      const dynamicCheckoutEvents = [
+      var dynamicCheckoutEvents = [
         "processout_dynamic_checkout_loading",
         "processout_dynamic_checkout_ready",
         "processout_dynamic_checkout_invoice_fetching_error",
@@ -167,7 +167,7 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
       ]
 
       document.addEventListener("DOMContentLoaded", function () {
-        const form = document.getElementById("dynamic-checkout-form")
+        var form = document.getElementById("dynamic-checkout-form")
 
         registerDynamicCheckoutEventHandlers(dynamicCheckoutEvents)
 
@@ -180,8 +180,8 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
       })
 
       function loadDynamicCheckoutFromForm() {
-        const dynamicCheckoutContainer = document.getElementById("dynamic-cko-container")
-        const formValues = getFormValues()
+        var dynamicCheckoutContainer = document.getElementById("dynamic-cko-container")
+        var formValues = getFormValues()
 
         clearFormError()
 
@@ -191,31 +191,33 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
         }
 
         clearEventLog()
-        dynamicCheckoutContainer.innerHTML = ""
+        dynamicCheckoutContainer.textContent = ""
 
         try {
-          const client = new ProcessOut.ProcessOut(formValues.projectId)
+          var client = new ProcessOut.ProcessOut(formValues.projectId)
 
-          const dynamicCheckout = client.setupDynamicCheckout(
-            {
-              invoiceId: formValues.invoiceId,
-              clientSecret: formValues.clientSecret,
-              locale: formValues.locale,
+          var dynamicCheckout = client.initDynamicCheckout({
+            invoiceId: formValues.invoiceId,
+            clientSecret: formValues.clientSecret,
+            locale: formValues.locale,
+            options: {
               capturePayments: formValues.capturePayments,
               allowFallbackToSale: formValues.allowFallbackToSale,
               enforceSavePaymentMethod: formValues.enforceSavePaymentMethod,
               hideSavedPaymentMethods: formValues.hideSavedPaymentMethods,
               showStatusMessage: formValues.showStatusMessage,
-              payButtonText: formValues.payButtonText,
-              cvcLabel: formValues.cvcLabel,
-              cvcPlaceholder: formValues.cvcPlaceholder,
-              additionalData: formValues.additionalData.value,
             },
-            {
+            theme: {
               payButtonColor: formValues.payButtonColor,
               payButtonTextColor: formValues.payButtonTextColor,
             },
-          )
+            text: {
+              payButtonText: formValues.payButtonText,
+              cvcLabel: formValues.cvcLabel,
+              cvcPlaceholder: formValues.cvcPlaceholder,
+            },
+            paymentMethodOverrides: buildPaymentMethodOverrides(formValues.additionalData.value),
+          })
 
           dynamicCheckout.mount("#dynamic-cko-container")
 
@@ -227,31 +229,38 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
       }
 
       function updateCodePreview(formValues) {
-        const config = {
+        var config = {
           invoiceId: formValues.invoiceId,
           clientSecret: formValues.clientSecret,
           locale: formValues.locale,
-          capturePayments: formValues.capturePayments,
-          allowFallbackToSale: formValues.allowFallbackToSale,
-          enforceSavePaymentMethod: formValues.enforceSavePaymentMethod,
-          hideSavedPaymentMethods: formValues.hideSavedPaymentMethods,
-          showStatusMessage: formValues.showStatusMessage,
-          payButtonText: formValues.payButtonText,
-          cvcLabel: formValues.cvcLabel,
-          cvcPlaceholder: formValues.cvcPlaceholder,
-          additionalData: formValues.additionalData.value,
+          options: {
+            capturePayments: formValues.capturePayments,
+            allowFallbackToSale: formValues.allowFallbackToSale,
+            enforceSavePaymentMethod: formValues.enforceSavePaymentMethod,
+            hideSavedPaymentMethods: formValues.hideSavedPaymentMethods,
+            showStatusMessage: formValues.showStatusMessage,
+          },
+          theme: {
+            payButtonColor: formValues.payButtonColor,
+            payButtonTextColor: formValues.payButtonTextColor,
+          },
+          text: {
+            payButtonText: formValues.payButtonText,
+            cvcLabel: formValues.cvcLabel,
+            cvcPlaceholder: formValues.cvcPlaceholder,
+          },
         }
 
-        const theme = {
-          payButtonColor: formValues.payButtonColor,
-          payButtonTextColor: formValues.payButtonTextColor,
+        var overrides = buildPaymentMethodOverrides(formValues.additionalData.value)
+
+        if (Object.keys(overrides).length > 0) {
+          config.paymentMethodOverrides = overrides
         }
 
-        const code =
+        var code =
           'const client = new ProcessOut.ProcessOut("' + formValues.projectId + '")\n\n' +
-          "const checkout = client.setupDynamicCheckout(\n" +
-          "  " + JSON.stringify(config, null, 2).replace(/\n/g, "\n  ") + ",\n" +
-          "  " + JSON.stringify(theme, null, 2).replace(/\n/g, "\n  ") + ",\n" +
+          "const checkout = client.initDynamicCheckout(" +
+          JSON.stringify(config, null, 2) +
           ")\n\n" +
           'checkout.mount("#dynamic-cko-container")'
 
@@ -259,41 +268,41 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
       }
 
       function getFormValues() {
-        const projectId = document.getElementById("project-id").value.trim()
-        const invoiceId = document.getElementById("invoice-id").value.trim()
-        const clientSecret = document.getElementById("client-secret").value.trim()
-        const locale = document.getElementById("locale").value.trim()
-        const payButtonText = document.getElementById("pay-button-text").value.trim()
-        const cvcLabel = document.getElementById("cvc-label").value.trim()
-        const cvcPlaceholder = document.getElementById("cvc-placeholder").value.trim()
-        const payButtonColor = document.getElementById("pay-button-color").value.trim()
-        const payButtonTextColor = document.getElementById("pay-button-text-color").value.trim()
-        const capturePayments = document.getElementById("capture-payments").checked
-        const allowFallbackToSale = document.getElementById("allow-fallback-to-sale").checked
-        const enforceSavePaymentMethod = document.getElementById(
+        var projectId = document.getElementById("project-id").value.trim()
+        var invoiceId = document.getElementById("invoice-id").value.trim()
+        var clientSecret = document.getElementById("client-secret").value.trim()
+        var locale = document.getElementById("locale").value.trim()
+        var payButtonText = document.getElementById("pay-button-text").value.trim()
+        var cvcLabel = document.getElementById("cvc-label").value.trim()
+        var cvcPlaceholder = document.getElementById("cvc-placeholder").value.trim()
+        var payButtonColor = document.getElementById("pay-button-color").value.trim()
+        var payButtonTextColor = document.getElementById("pay-button-text-color").value.trim()
+        var capturePayments = document.getElementById("capture-payments").checked
+        var allowFallbackToSale = document.getElementById("allow-fallback-to-sale").checked
+        var enforceSavePaymentMethod = document.getElementById(
           "enforce-safe-payment-method",
         ).checked
-        const hideSavedPaymentMethods = document.getElementById(
+        var hideSavedPaymentMethods = document.getElementById(
           "hide-saved-payment-methods",
         ).checked
-        const showStatusMessage = document.getElementById("show-status-message").checked
-        const additionalDataValue = document.getElementById("additional-data").value.trim()
+        var showStatusMessage = document.getElementById("show-status-message").checked
+        var additionalDataValue = document.getElementById("additional-data").value.trim()
 
         return {
-          projectId,
-          invoiceId,
-          clientSecret,
-          locale,
-          capturePayments,
-          allowFallbackToSale,
-          enforceSavePaymentMethod,
-          hideSavedPaymentMethods,
-          showStatusMessage,
-          payButtonText,
-          cvcLabel,
-          cvcPlaceholder,
-          payButtonColor,
-          payButtonTextColor,
+          projectId: projectId,
+          invoiceId: invoiceId,
+          clientSecret: clientSecret,
+          locale: locale,
+          capturePayments: capturePayments,
+          allowFallbackToSale: allowFallbackToSale,
+          enforceSavePaymentMethod: enforceSavePaymentMethod,
+          hideSavedPaymentMethods: hideSavedPaymentMethods,
+          showStatusMessage: showStatusMessage,
+          payButtonText: payButtonText,
+          cvcLabel: cvcLabel,
+          cvcPlaceholder: cvcPlaceholder,
+          payButtonColor: payButtonColor,
+          payButtonTextColor: payButtonTextColor,
           additionalData: parseAdditionalData(additionalDataValue),
         }
       }
@@ -322,6 +331,20 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
         }
       }
 
+      function buildPaymentMethodOverrides(additionalDataByMethod) {
+        var overrides = {}
+
+        for (var methodKey in additionalDataByMethod) {
+          if (additionalDataByMethod.hasOwnProperty(methodKey)) {
+            overrides[methodKey] = {
+              additionalData: additionalDataByMethod[methodKey],
+            }
+          }
+        }
+
+        return overrides
+      }
+
       function registerDynamicCheckoutEventHandlers(events) {
         events.forEach(function (eventName) {
           window.addEventListener(eventName, function (event) {
@@ -332,12 +355,12 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
       }
 
       function appendEventLog(eventName, detail) {
-        const eventLog = document.getElementById("dynamic-checkout-event-log")
-        const eventItem = document.createElement("li")
-        const eventTimestamp = document.createElement("span")
-        const eventNameElement = document.createElement("strong")
-        const eventDetail = document.createElement("pre")
-        const timestamp = new Date().toLocaleTimeString()
+        var eventLog = document.getElementById("dynamic-checkout-event-log")
+        var eventItem = document.createElement("li")
+        var eventTimestamp = document.createElement("span")
+        var eventNameElement = document.createElement("strong")
+        var eventDetail = document.createElement("pre")
+        var timestamp = new Date().toLocaleTimeString()
 
         eventTimestamp.className = "event-log-time"
         eventTimestamp.textContent = timestamp
@@ -357,18 +380,18 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
       }
 
       function clearEventLog() {
-        document.getElementById("dynamic-checkout-event-log").innerHTML = ""
+        document.getElementById("dynamic-checkout-event-log").textContent = ""
       }
 
       function clearFormError() {
-        const formError = document.getElementById("form-error")
+        var formError = document.getElementById("form-error")
 
         formError.hidden = true
         formError.textContent = ""
       }
 
       function showFormError(message) {
-        const formError = document.getElementById("form-error")
+        var formError = document.getElementById("form-error")
 
         formError.hidden = false
         formError.textContent = message

--- a/examples/dynamic-checkout-init/index.html
+++ b/examples/dynamic-checkout-init/index.html
@@ -102,7 +102,7 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
                   name="enforceSavePaymentMethod"
                   type="checkbox"
                 />
-                <span>Enforce Safe Payment Method</span>
+                <span>Enforce Save Payment Method</span>
               </label>
 
               <label class="form-field form-field-toggle">

--- a/examples/dynamic-checkout/index.html
+++ b/examples/dynamic-checkout/index.html
@@ -251,7 +251,7 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NzMwNzM0MDksImludm9pY2VfaWQiOiJ
           'const client = new ProcessOut.ProcessOut("' + formValues.projectId + '")\n\n' +
           "const checkout = client.setupDynamicCheckout(\n" +
           "  " + JSON.stringify(config, null, 2).replace(/\n/g, "\n  ") + ",\n" +
-          "  " + JSON.stringify(theme, null, 2).replace(/\n/g, "\n  ") + ",\n" +
+          "  " + JSON.stringify(theme, null, 2).replace(/\n/g, "\n  ") + "\n" +
           ")\n\n" +
           'checkout.mount("#dynamic-cko-container")'
 

--- a/examples/dynamic-checkout/styles.css
+++ b/examples/dynamic-checkout/styles.css
@@ -153,6 +153,21 @@ pre {
   padding: 10px;
 }
 
+.code-preview {
+  background: #1e293b;
+  color: #e2e8f0;
+  border-radius: 12px;
+  padding: 16px;
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
 #dynamic-cko-container {
   width: 100%;
   max-width: 420px;

--- a/index.html
+++ b/index.html
@@ -55,6 +55,9 @@
         <a href="examples/dynamic-checkout/index.html">Dynamic Checkout</a>
       </li>
       <li>
+        <a href="examples/dynamic-checkout-init/index.html">Dynamic Checkout (initDynamicCheckout)</a>
+      </li>
+      <li>
         <a href="examples/native-apm/index.html">Native APM</a>
       </li>
       <li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.8.9",
+  "version": "1.9.0",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/dynamic-checkout/clients/apple-pay.ts
+++ b/src/dynamic-checkout/clients/apple-pay.ts
@@ -2,6 +2,8 @@
 
 module ProcessOut {
   export class ApplePayClient {
+    private static readonly METHOD_KEY = "applepay"
+
     processOutInstance: ProcessOut
     paymentConfig: DynamicCheckoutPaymentConfig
 
@@ -16,6 +18,7 @@ module ProcessOut {
       getViewContainer: () => HTMLElement,
     ) {
       const applePayScript = document.createElement("script")
+
       applePayScript.src = applePaySdkUrl
       applePayScript.onload = () => {
         buttonContainer.innerHTML = `<apple-pay-button buttonstyle="white-outline" type="plain" locale="en-US"></apple-pay-button>`
@@ -139,21 +142,23 @@ module ProcessOut {
       invoiceData: Invoice,
       getViewContainer: () => HTMLElement,
     ) {
+      const methodOptions = this.paymentConfig.getOptionsForMethod(ApplePayClient.METHOD_KEY)
+
       this.processOutInstance.makeCardPayment(
         invoiceData.id,
         cardToken,
         {
-          authorize_only: !this.paymentConfig.capturePayments,
-          allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
+          authorize_only: !methodOptions.capturePayments,
+          allow_fallback_to_sale: !!methodOptions.allowFallbackToSale,
         },
         invoiceId => {
-          if (this.paymentConfig.showStatusMessage) {
+          if (methodOptions.showStatusMessage) {
             getViewContainer().appendChild(
               new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
                 .element,
             )
           } else if (
-            !this.paymentConfig.showStatusMessage &&
+            !methodOptions.showStatusMessage &&
             !this.paymentConfig.invoiceDetails.return_url
           ) {
             getViewContainer().appendChild(
@@ -169,13 +174,13 @@ module ProcessOut {
           })
         },
         error => {
-          if (this.paymentConfig.showStatusMessage) {
+          if (methodOptions.showStatusMessage) {
             getViewContainer().appendChild(
               new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
                 .element,
             )
           } else if (
-            !this.paymentConfig.showStatusMessage &&
+            !methodOptions.showStatusMessage &&
             !this.paymentConfig.invoiceDetails.return_url
           ) {
             getViewContainer().appendChild(
@@ -194,7 +199,7 @@ module ProcessOut {
         },
         undefined,
         invoiceId => {
-          if (this.paymentConfig.showStatusMessage) {
+          if (methodOptions.showStatusMessage) {
             getViewContainer().appendChild(
               new DynamicCheckoutPaymentPendingView(this.processOutInstance, this.paymentConfig)
                 .element,

--- a/src/dynamic-checkout/clients/google-pay.ts
+++ b/src/dynamic-checkout/clients/google-pay.ts
@@ -48,6 +48,8 @@ module ProcessOut {
     }
   }
   export class GooglePayClient {
+    private static readonly METHOD_KEY = "googlepay"
+
     googleClient: any
     processOutInstance: ProcessOut
     paymentConfig: DynamicCheckoutPaymentConfig
@@ -120,6 +122,8 @@ module ProcessOut {
     }
 
     private makePayment(invoiceData: Invoice, getViewContainer: () => HTMLElement) {
+      const methodOptions = this.paymentConfig.getOptionsForMethod(GooglePayClient.METHOD_KEY)
+
       this.googleClient
         .loadPaymentData(this.paymentRequest)
         .then(paymentData => {
@@ -136,21 +140,18 @@ module ProcessOut {
                 invoiceData.id,
                 token,
                 {
-                  authorize_only: !this.paymentConfig.capturePayments,
-                  allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
+                  authorize_only: !methodOptions.capturePayments,
+                  allow_fallback_to_sale: !!methodOptions.allowFallbackToSale,
                 },
                 invoiceId => {
-                  if (this.paymentConfig.showStatusMessage) {
+                  if (methodOptions.showStatusMessage) {
                     getViewContainer().appendChild(
                       new DynamicCheckoutPaymentSuccessView(
                         this.processOutInstance,
                         this.paymentConfig,
                       ).element,
                     )
-                  } else if (
-                    !this.paymentConfig.showStatusMessage &&
-                    !this.paymentConfig.invoiceDetails.return_url
-                  ) {
+                  } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
                     getViewContainer().appendChild(
                       new DynamicCheckoutPaymentInfoView(
                         this.processOutInstance,
@@ -166,17 +167,14 @@ module ProcessOut {
                   })
                 },
                 error => {
-                  if (this.paymentConfig.showStatusMessage) {
+                  if (methodOptions.showStatusMessage) {
                     getViewContainer().appendChild(
                       new DynamicCheckoutPaymentErrorView(
                         this.processOutInstance,
                         this.paymentConfig,
                       ).element,
                     )
-                  } else if (
-                    !this.paymentConfig.showStatusMessage &&
-                    !this.paymentConfig.invoiceDetails.return_url
-                  ) {
+                  } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
                     getViewContainer().appendChild(
                       new DynamicCheckoutPaymentInfoView(
                         this.processOutInstance,
@@ -195,7 +193,7 @@ module ProcessOut {
                 },
                 undefined,
                 invoiceId => {
-                  if (this.paymentConfig.showStatusMessage) {
+                  if (methodOptions.showStatusMessage) {
                     getViewContainer().appendChild(
                       new DynamicCheckoutPaymentPendingView(this.processOutInstance, this.paymentConfig).element,
                     )

--- a/src/dynamic-checkout/config/payment-config.ts
+++ b/src/dynamic-checkout/config/payment-config.ts
@@ -1,13 +1,103 @@
 /// <reference path="../references.ts" />
 
 module ProcessOut {
-  interface DynamicCheckoutAdditionalDataByGateway {
-    [gatewayName: string]: Record<string, string>
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  type DynamicCheckoutMethodKey = string
+
+  interface DynamicCheckoutMethodScopedConfig<T> {
+    _global?: T
+    [methodKey: string]: T | undefined
   }
 
+  function cloneMethodScopedConfig<T extends Record<string, any>>(
+    config?: DynamicCheckoutMethodScopedConfig<T>,
+  ): DynamicCheckoutMethodScopedConfig<T> {
+    const clonedConfig: DynamicCheckoutMethodScopedConfig<T> = {}
+
+    if (!config) {
+      return clonedConfig
+    }
+
+    for (const key in config) {
+      if (config[key]) {
+        clonedConfig[key] = {
+          ...config[key],
+        }
+      }
+    }
+
+    return clonedConfig
+  }
+
+  function getScopedConfigValue<T extends Record<string, any>>(
+    config: DynamicCheckoutMethodScopedConfig<T>,
+    methodKey: DynamicCheckoutMethodKey,
+  ): T {
+    return {
+      ...(config._global || {}),
+      ...(config[methodKey] || {}),
+    } as T
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared value types (used by both old and new public APIs)
+  // ---------------------------------------------------------------------------
+
+  export type DynamicCheckoutAdditionalPaymentDataType = Record<string, string>
+
+  export type DynamicCheckoutOptionsType = {
+    capturePayments?: boolean
+    allowFallbackToSale?: boolean
+    enforceSavePaymentMethod?: boolean
+    hideSavedPaymentMethods?: boolean
+    showStatusMessage?: boolean
+  }
+
+  export type DynamicCheckoutTextOverridesType = {
+    payButtonText?: string
+    cvcLabel?: string
+    cvcPlaceholder?: string
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API: initDynamicCheckout (current)
+  // ---------------------------------------------------------------------------
+
+  export type DynamicCheckoutPaymentMethodKey =
+    | "card"
+    | "applepay"
+    | "googlepay"
+    | (string & {})
+
+  export type DynamicCheckoutPaymentMethodOverrideType = {
+    options?: DynamicCheckoutOptionsType
+    theme?: DynamicCheckoutThemeType
+    text?: DynamicCheckoutTextOverridesType
+    additionalData?: DynamicCheckoutAdditionalPaymentDataType
+  }
+
+  export type DynamicCheckoutInitConfigType = {
+    invoiceId: string
+    clientSecret?: string
+    locale?: string
+    options?: DynamicCheckoutOptionsType
+    theme?: DynamicCheckoutThemeType
+    text?: DynamicCheckoutTextOverridesType
+    paymentMethodOverrides?: Partial<
+      Record<DynamicCheckoutPaymentMethodKey, DynamicCheckoutPaymentMethodOverrideType>
+    >
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API: setupDynamicCheckout (deprecated)
+  // ---------------------------------------------------------------------------
+
+  /** @deprecated Use DynamicCheckoutInitConfigType instead */
   export type DynamicCheckoutPublicConfigType = {
     invoiceId: string
-    projectId: string
     locale?: string
     clientSecret?: string
     capturePayments?: boolean
@@ -16,53 +106,198 @@ module ProcessOut {
     hideSavedPaymentMethods?: boolean
     showStatusMessage?: boolean
     payButtonText?: string
-    additionalData?: DynamicCheckoutAdditionalDataByGateway
+    additionalData?: Record<string, DynamicCheckoutAdditionalPaymentDataType>
     cvcLabel?: string
     cvcPlaceholder?: string
+  }
+
+  /** @deprecated Use DynamicCheckoutInitConfigType instead */
+  export type DynamicCheckoutInitPublicConfigType = {
+    invoiceId: string
+    locale?: string
+    clientSecret?: string
+    options?: DynamicCheckoutMethodScopedConfig<DynamicCheckoutOptionsType>
+    theme?: DynamicCheckoutMethodScopedConfig<DynamicCheckoutThemeType>
+    textOverrides?: DynamicCheckoutMethodScopedConfig<DynamicCheckoutTextOverridesType>
+    additionalPaymentData?: DynamicCheckoutMethodScopedConfig<DynamicCheckoutAdditionalPaymentDataType>
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal normalized config (all public APIs normalize into this)
+  // ---------------------------------------------------------------------------
+
+  export type DynamicCheckoutNormalizedPublicConfigType = {
+    invoiceId: string
+    projectId: string
+    locale?: string
+    clientSecret?: string
+    optionsByMethod?: DynamicCheckoutMethodScopedConfig<DynamicCheckoutOptionsType>
+    themeByMethod?: DynamicCheckoutMethodScopedConfig<DynamicCheckoutThemeType>
+    textOverridesByMethod?: DynamicCheckoutMethodScopedConfig<DynamicCheckoutTextOverridesType>
+    additionalPaymentDataByMethod?: DynamicCheckoutMethodScopedConfig<DynamicCheckoutAdditionalPaymentDataType>
   }
 
   export type DynamicCheckoutInternalConfigType = {
     invoiceDetails: Invoice
   }
 
-  export type DynamicCheckoutConfigType = DynamicCheckoutPublicConfigType &
+  export type DynamicCheckoutConfigType = DynamicCheckoutNormalizedPublicConfigType &
     DynamicCheckoutInternalConfigType
 
+  // ---------------------------------------------------------------------------
+  // Normalization functions
+  // ---------------------------------------------------------------------------
+
+  export function normalizeDynamicCheckoutConfig(
+    config: DynamicCheckoutInitConfigType & { projectId: string },
+  ): DynamicCheckoutNormalizedPublicConfigType {
+    const optionsByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutOptionsType> = {
+      _global: { ...(config.options || {}) },
+    }
+
+    const themeByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutThemeType> = {
+      _global: config.theme ? { ...config.theme } : {},
+    }
+
+    const textOverridesByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutTextOverridesType> = {
+      _global: config.text ? { ...config.text } : {},
+    }
+
+    const additionalPaymentDataByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutAdditionalPaymentDataType> = {}
+
+    if (config.paymentMethodOverrides) {
+      for (const key in config.paymentMethodOverrides) {
+        const override = config.paymentMethodOverrides[key]
+
+        if (!override) {
+          continue
+        }
+
+        if (override.options) {
+          optionsByMethod[key] = { ...override.options }
+        }
+
+        if (override.theme) {
+          themeByMethod[key] = { ...override.theme }
+        }
+
+        if (override.text) {
+          textOverridesByMethod[key] = { ...override.text }
+        }
+
+        if (override.additionalData) {
+          additionalPaymentDataByMethod[key] = { ...override.additionalData }
+        }
+      }
+    }
+
+    return {
+      invoiceId: config.invoiceId,
+      projectId: config.projectId,
+      locale: config.locale,
+      clientSecret: config.clientSecret,
+      optionsByMethod,
+      themeByMethod,
+      textOverridesByMethod,
+      additionalPaymentDataByMethod,
+    }
+  }
+
+  /** @deprecated */
+  export function normalizeDynamicCheckoutSetupConfig(
+    config: DynamicCheckoutPublicConfigType & {
+      projectId: string
+    },
+    theme?: DynamicCheckoutThemeType,
+  ): DynamicCheckoutNormalizedPublicConfigType {
+    return {
+      invoiceId: config.invoiceId,
+      projectId: config.projectId,
+      locale: config.locale,
+      clientSecret: config.clientSecret,
+      optionsByMethod: {
+        _global: {
+          capturePayments: config.capturePayments,
+          allowFallbackToSale: config.allowFallbackToSale,
+          enforceSavePaymentMethod: config.enforceSavePaymentMethod,
+          hideSavedPaymentMethods: config.hideSavedPaymentMethods,
+          showStatusMessage: config.showStatusMessage,
+        },
+      },
+      themeByMethod: {
+        _global: theme ? { ...theme } : {},
+      },
+      textOverridesByMethod: {
+        _global: {
+          payButtonText: config.payButtonText,
+          cvcLabel: config.cvcLabel,
+          cvcPlaceholder: config.cvcPlaceholder,
+        },
+      },
+      additionalPaymentDataByMethod: cloneMethodScopedConfig(config.additionalData),
+    }
+  }
+
+  /** @deprecated */
+  export function normalizeDynamicCheckoutInitConfig(
+    config: DynamicCheckoutInitPublicConfigType & {
+      projectId: string
+    },
+  ): DynamicCheckoutNormalizedPublicConfigType {
+    return {
+      invoiceId: config.invoiceId,
+      projectId: config.projectId,
+      locale: config.locale,
+      clientSecret: config.clientSecret,
+      optionsByMethod: cloneMethodScopedConfig(config.options),
+      themeByMethod: cloneMethodScopedConfig(config.theme),
+      textOverridesByMethod: cloneMethodScopedConfig(config.textOverrides),
+      additionalPaymentDataByMethod: cloneMethodScopedConfig(config.additionalPaymentData),
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Runtime config class
+  // ---------------------------------------------------------------------------
+
   export class DynamicCheckoutPaymentConfig {
-    invoiceId: DynamicCheckoutPublicConfigType["invoiceId"]
-    projectId: DynamicCheckoutPublicConfigType["projectId"]
-    clientSecret: DynamicCheckoutPublicConfigType["clientSecret"]
-    locale: DynamicCheckoutPublicConfigType["locale"] = "en"
-    capturePayments: DynamicCheckoutPublicConfigType["capturePayments"] = false
-    allowFallbackToSale: DynamicCheckoutPublicConfigType["allowFallbackToSale"] = false
-    enforceSavePaymentMethod: DynamicCheckoutPublicConfigType["enforceSavePaymentMethod"] = false
-    hideSavedPaymentMethods: DynamicCheckoutPublicConfigType["hideSavedPaymentMethods"] = false
-    showStatusMessage: DynamicCheckoutPublicConfigType["showStatusMessage"] = true
-    payButtonText: DynamicCheckoutPublicConfigType["payButtonText"] = ""
-    additionalData: DynamicCheckoutPublicConfigType["additionalData"] = {}
-    cvcLabel: DynamicCheckoutPublicConfigType["cvcLabel"] = ""
-    cvcPlaceholder: DynamicCheckoutPublicConfigType["cvcPlaceholder"] = ""
+    invoiceId: DynamicCheckoutNormalizedPublicConfigType["invoiceId"]
+    projectId: DynamicCheckoutNormalizedPublicConfigType["projectId"]
+    clientSecret: DynamicCheckoutNormalizedPublicConfigType["clientSecret"]
+    locale: DynamicCheckoutNormalizedPublicConfigType["locale"] = "en"
+    capturePayments: boolean = false
+    allowFallbackToSale: boolean = false
+    enforceSavePaymentMethod: boolean = false
+    hideSavedPaymentMethods: boolean = false
+    showStatusMessage: boolean = true
+    payButtonText: string = ""
+    additionalData: DynamicCheckoutAdditionalPaymentDataType = {}
+    cvcLabel: string = ""
+    cvcPlaceholder: string = ""
     invoiceDetails: DynamicCheckoutInternalConfigType["invoiceDetails"]
 
-    constructor(config: DynamicCheckoutPublicConfigType) {
+    private optionsByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutOptionsType> = {}
+    private themeByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutThemeType> = {}
+    private textOverridesByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutTextOverridesType> =
+      {}
+    private additionalPaymentDataByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutAdditionalPaymentDataType> =
+      {}
+
+    constructor(config: DynamicCheckoutNormalizedPublicConfigType) {
       this.setInitialConfig(config)
     }
 
-    public getConfig(): DynamicCheckoutPublicConfigType & DynamicCheckoutInternalConfigType {
+    public getConfig(): DynamicCheckoutConfigType {
       return {
         invoiceId: this.invoiceId,
         projectId: this.projectId,
         locale: this.locale,
+        clientSecret: this.clientSecret,
         invoiceDetails: this.invoiceDetails,
-        capturePayments: this.capturePayments,
-        allowFallbackToSale: this.allowFallbackToSale,
-        enforceSavePaymentMethod: this.enforceSavePaymentMethod,
-        hideSavedPaymentMethods: this.hideSavedPaymentMethods,
-        showStatusMessage: this.showStatusMessage,
-        additionalData: this.additionalData,
-        payButtonText: this.payButtonText,
-        cvcLabel: this.cvcLabel,
-        cvcPlaceholder: this.cvcPlaceholder,
+        optionsByMethod: cloneMethodScopedConfig(this.optionsByMethod),
+        themeByMethod: cloneMethodScopedConfig(this.themeByMethod),
+        textOverridesByMethod: cloneMethodScopedConfig(this.textOverridesByMethod),
+        additionalPaymentDataByMethod: cloneMethodScopedConfig(this.additionalPaymentDataByMethod),
       }
     }
 
@@ -70,38 +305,82 @@ module ProcessOut {
       this.invoiceDetails = invoiceDetails
     }
 
-    public getAdditionalDataForGateway(gatewayName: string): Record<string, string> {
-      return this.additionalData[gatewayName] || {}
+    public getOptionsForMethod(methodKey: DynamicCheckoutMethodKey): DynamicCheckoutOptionsType {
+      return {
+        capturePayments: this.capturePayments,
+        allowFallbackToSale: this.allowFallbackToSale,
+        enforceSavePaymentMethod: this.enforceSavePaymentMethod,
+        hideSavedPaymentMethods: this.hideSavedPaymentMethods,
+        showStatusMessage: this.showStatusMessage,
+        ...getScopedConfigValue(this.optionsByMethod, methodKey),
+      }
     }
 
-    private setInitialConfig(config: DynamicCheckoutPublicConfigType) {
+    public getThemeForMethod(methodKey: DynamicCheckoutMethodKey): DynamicCheckoutThemeType {
+      return getScopedConfigValue(this.themeByMethod, methodKey)
+    }
+
+    public getTextOverridesForMethod(
+      methodKey: DynamicCheckoutMethodKey,
+    ): DynamicCheckoutTextOverridesType {
+      return {
+        payButtonText: this.payButtonText,
+        cvcLabel: this.cvcLabel,
+        cvcPlaceholder: this.cvcPlaceholder,
+        ...getScopedConfigValue(this.textOverridesByMethod, methodKey),
+      }
+    }
+
+    public getAdditionalDataForMethod(
+      methodKey: DynamicCheckoutMethodKey,
+    ): DynamicCheckoutAdditionalPaymentDataType {
+      return getScopedConfigValue(this.additionalPaymentDataByMethod, methodKey)
+    }
+
+    public getAdditionalDataForGateway(
+      gatewayName: DynamicCheckoutMethodKey,
+    ): DynamicCheckoutAdditionalPaymentDataType {
+      return this.getAdditionalDataForMethod(gatewayName)
+    }
+
+    private setInitialConfig(config: DynamicCheckoutNormalizedPublicConfigType) {
       if (!this.isValidConfig(config)) {
         throw new Error(
           "You must instantiate Dynamic Checkout with a valid config in order to use it",
         )
       }
 
+      this.optionsByMethod = cloneMethodScopedConfig(config.optionsByMethod)
+      this.themeByMethod = cloneMethodScopedConfig(config.themeByMethod)
+      this.textOverridesByMethod = cloneMethodScopedConfig(config.textOverridesByMethod)
+      this.additionalPaymentDataByMethod = cloneMethodScopedConfig(
+        config.additionalPaymentDataByMethod,
+      )
+
+      const globalOptions = this.getOptionsForMethod("_global")
+      const globalTextOverrides = this.getTextOverridesForMethod("_global")
+
       this.invoiceId = config.invoiceId
       this.projectId = config.projectId
       this.clientSecret = config.clientSecret
       this.locale = config.locale || "en"
-      this.capturePayments = config.capturePayments || false
-      this.allowFallbackToSale = config.allowFallbackToSale || false
-      this.enforceSavePaymentMethod = config.enforceSavePaymentMethod || false
-      this.hideSavedPaymentMethods = config.hideSavedPaymentMethods || false
-      this.payButtonText = config.payButtonText || ""
-      this.additionalData = config.additionalData || {}
-      this.cvcLabel = config.cvcLabel || ""
-      this.cvcPlaceholder = config.cvcPlaceholder || ""
+      this.capturePayments = globalOptions.capturePayments || false
+      this.allowFallbackToSale = globalOptions.allowFallbackToSale || false
+      this.enforceSavePaymentMethod = globalOptions.enforceSavePaymentMethod || false
+      this.hideSavedPaymentMethods = globalOptions.hideSavedPaymentMethods || false
+      this.payButtonText = globalTextOverrides.payButtonText ?? ""
+      this.additionalData = this.getAdditionalDataForMethod("_global")
+      this.cvcLabel = globalTextOverrides.cvcLabel ?? ""
+      this.cvcPlaceholder = globalTextOverrides.cvcPlaceholder ?? ""
 
-      if (config.showStatusMessage !== undefined && config.showStatusMessage !== null) {
-        this.showStatusMessage = config.showStatusMessage
+      if (globalOptions.showStatusMessage !== undefined && globalOptions.showStatusMessage !== null) {
+        this.showStatusMessage = globalOptions.showStatusMessage
       } else {
         this.showStatusMessage = true
       }
     }
 
-    private isValidConfig(config: DynamicCheckoutPublicConfigType) {
+    private isValidConfig(config: DynamicCheckoutNormalizedPublicConfigType) {
       return !!config.projectId && !!config.invoiceId
     }
   }

--- a/src/dynamic-checkout/config/payment-config.ts
+++ b/src/dynamic-checkout/config/payment-config.ts
@@ -12,6 +12,10 @@ module ProcessOut {
     [methodKey: string]: T | undefined
   }
 
+  function isSafeMethodScopedConfigKey(key: string): boolean {
+    return key !== "__proto__" && key !== "constructor" && key !== "prototype"
+  }
+
   function cloneMethodScopedConfig<T extends Record<string, any>>(
     config?: DynamicCheckoutMethodScopedConfig<T>,
   ): DynamicCheckoutMethodScopedConfig<T> {
@@ -21,13 +25,17 @@ module ProcessOut {
       return clonedConfig
     }
 
-    for (const key in config) {
+    Object.keys(config).forEach(key => {
+      if (!isSafeMethodScopedConfigKey(key)) {
+        return
+      }
+
       if (config[key]) {
         clonedConfig[key] = {
           ...config[key],
         }
       }
-    }
+    })
 
     return clonedConfig
   }
@@ -166,11 +174,15 @@ module ProcessOut {
     const additionalPaymentDataByMethod: DynamicCheckoutMethodScopedConfig<DynamicCheckoutAdditionalPaymentDataType> = {}
 
     if (config.paymentMethodOverrides) {
-      for (const key in config.paymentMethodOverrides) {
+      Object.keys(config.paymentMethodOverrides).forEach(key => {
+        if (!isSafeMethodScopedConfigKey(key)) {
+          return
+        }
+
         const override = config.paymentMethodOverrides[key]
 
         if (!override) {
-          continue
+          return
         }
 
         if (override.options) {
@@ -188,7 +200,7 @@ module ProcessOut {
         if (override.additionalData) {
           additionalPaymentDataByMethod[key] = { ...override.additionalData }
         }
-      }
+      })
     }
 
     return {

--- a/src/dynamic-checkout/config/payment-config.ts
+++ b/src/dynamic-checkout/config/payment-config.ts
@@ -40,6 +40,18 @@ module ProcessOut {
     return clonedConfig
   }
 
+  function pickDefined<T extends Record<string, any>>(source: T): Partial<T> {
+    const result: Partial<T> = {}
+
+    Object.keys(source).forEach(key => {
+      if (source[key] !== undefined) {
+        result[key as keyof T] = source[key]
+      }
+    })
+
+    return result
+  }
+
   function getScopedConfigValue<T extends Record<string, any>>(
     config: DynamicCheckoutMethodScopedConfig<T>,
     methodKey: DynamicCheckoutMethodKey,
@@ -228,23 +240,23 @@ module ProcessOut {
       locale: config.locale,
       clientSecret: config.clientSecret,
       optionsByMethod: {
-        _global: {
+        _global: pickDefined({
           capturePayments: config.capturePayments,
           allowFallbackToSale: config.allowFallbackToSale,
           enforceSavePaymentMethod: config.enforceSavePaymentMethod,
           hideSavedPaymentMethods: config.hideSavedPaymentMethods,
           showStatusMessage: config.showStatusMessage,
-        },
+        }),
       },
       themeByMethod: {
         _global: theme ? { ...theme } : {},
       },
       textOverridesByMethod: {
-        _global: {
+        _global: pickDefined({
           payButtonText: config.payButtonText,
           cvcLabel: config.cvcLabel,
           cvcPlaceholder: config.cvcPlaceholder,
-        },
+        }),
       },
       additionalPaymentDataByMethod: cloneMethodScopedConfig(config.additionalData),
     }

--- a/src/dynamic-checkout/dynamic-checkout.ts
+++ b/src/dynamic-checkout/dynamic-checkout.ts
@@ -6,20 +6,14 @@ module ProcessOut {
     widgetWrapper: Element
     processOutInstance: ProcessOut
     paymentConfig: DynamicCheckoutPaymentConfig
-    theme: DynamicCheckoutTheme
     invoiceDetails: Invoice
 
     constructor(
       processOutInstance: ProcessOut,
-      config: DynamicCheckoutPublicConfigType,
-      theme?: DynamicCheckoutThemeType,
+      config: DynamicCheckoutNormalizedPublicConfigType,
     ) {
       this.processOutInstance = processOutInstance
       this.paymentConfig = new DynamicCheckoutPaymentConfig(config)
-
-      if (theme) {
-        this.theme = new DynamicCheckoutTheme(theme)
-      }
 
       this.applyDefaultStyles()
     }
@@ -45,7 +39,6 @@ module ProcessOut {
         this,
         this.processOutInstance,
         this.paymentConfig,
-        this.theme,
       )
 
       this.loadView(paymentMethodsView.element)

--- a/src/dynamic-checkout/payment-methods/apm.ts
+++ b/src/dynamic-checkout/payment-methods/apm.ts
@@ -16,14 +16,12 @@ module ProcessOut {
     protected processOutInstance: ProcessOut
     private paymentConfig: DynamicCheckoutPaymentConfig
     private paymentMethod: PaymentMethod
-    private theme: DynamicCheckoutThemeType
     private resetContainerHtml: () => HTMLElement
 
     constructor(
       processOutInstance: ProcessOut,
       paymentMethod: PaymentMethod,
       paymentConfig: DynamicCheckoutPaymentConfig,
-      theme: DynamicCheckoutThemeType,
       resetContainerHtml: () => HTMLElement,
     ) {
       super(
@@ -36,16 +34,40 @@ module ProcessOut {
       this.processOutInstance = processOutInstance
       this.paymentConfig = paymentConfig
       this.paymentMethod = paymentMethod
-      this.theme = theme
       this.resetContainerHtml = resetContainerHtml
 
       super.appendChildren(this.getChildrenElement())
+    }
+
+    private getMethodKey() {
+      return this.paymentMethod.apm.gateway_name
+    }
+
+    private getMethodOptions() {
+      return this.paymentConfig.getOptionsForMethod(this.getMethodKey())
+    }
+
+    private getMethodTheme() {
+      return this.paymentConfig.getThemeForMethod(this.getMethodKey())
+    }
+
+    private getTextOverrides() {
+      return this.paymentConfig.getTextOverridesForMethod(this.getMethodKey())
+    }
+
+    private getAdditionalPaymentData() {
+      return this.paymentConfig.getAdditionalDataForMethod(this.getMethodKey())
+    }
+
+    private shouldShowStatusMessage() {
+      return this.getMethodOptions().showStatusMessage
     }
 
     private proceedToApmPayment() {
       const { apm } = this.paymentMethod
       const { clientSecret } = this.paymentConfig
       const canSavePaymentMethod = apm.saving_allowed
+      const methodOptions = this.getMethodOptions()
 
       const actionHandlerOptions = new ActionHandlerOptions(
         apm.gateway_name,
@@ -53,9 +75,9 @@ module ProcessOut {
       )
 
       const cardPaymentOptions = {
-        authorize_only: !this.paymentConfig.capturePayments,
-        allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
-        save_source: canSavePaymentMethod && this.paymentConfig.enforceSavePaymentMethod,
+        authorize_only: !methodOptions.capturePayments,
+        allow_fallback_to_sale: !!methodOptions.allowFallbackToSale,
+        save_source: canSavePaymentMethod && !!methodOptions.enforceSavePaymentMethod,
       }
 
       const requestOptions = {
@@ -69,7 +91,7 @@ module ProcessOut {
       if (
         canSavePaymentMethod &&
         saveForFutureCheckbox &&
-        !this.paymentConfig.enforceSavePaymentMethod
+        !methodOptions.enforceSavePaymentMethod
       ) {
         cardPaymentOptions["save_source"] = saveForFutureCheckbox.checked
       }
@@ -91,7 +113,7 @@ module ProcessOut {
       requestOptions: RequestOptions,
     ) {
       const { apm } = this.paymentMethod
-      const additionalData = this.paymentConfig.getAdditionalDataForGateway(apm.gateway_name)
+      const additionalData = this.getAdditionalPaymentData()
 
       const redirectUrl =
         Object.keys(additionalData).length > 0
@@ -116,15 +138,12 @@ module ProcessOut {
             paymentToken,
             cardPaymentOptions,
             invoiceId => {
-              if (this.paymentConfig.showStatusMessage) {
+              if (this.shouldShowStatusMessage()) {
                 this.resetContainerHtml().appendChild(
                   new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
                     .element,
                 )
-              } else if (
-                !this.paymentConfig.showStatusMessage &&
-                !this.paymentConfig.invoiceDetails.return_url
-              ) {
+              } else if (!this.shouldShowStatusMessage() && !this.paymentConfig.invoiceDetails.return_url) {
                 this.resetContainerHtml().appendChild(
                   new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig)
                     .element,
@@ -269,7 +288,7 @@ module ProcessOut {
                 paymentToken,
                 options,
                 invoiceId => {
-                  if (this.paymentConfig.showStatusMessage) {
+                  if (this.shouldShowStatusMessage()) {
                     this.resetContainerHtml().appendChild(
                       new DynamicCheckoutPaymentSuccessView(
                         this.processOutInstance,
@@ -277,7 +296,7 @@ module ProcessOut {
                       ).element,
                     )
                   } else if (
-                    !this.paymentConfig.showStatusMessage &&
+                    !this.shouldShowStatusMessage() &&
                     !this.paymentConfig.invoiceDetails.return_url
                   ) {
                     this.resetContainerHtml().appendChild(
@@ -296,7 +315,7 @@ module ProcessOut {
                   })
                 },
                 error => {
-                  if (this.paymentConfig.showStatusMessage) {
+                  if (this.shouldShowStatusMessage()) {
                     this.resetContainerHtml().appendChild(
                       new DynamicCheckoutPaymentErrorView(
                         this.processOutInstance,
@@ -304,7 +323,7 @@ module ProcessOut {
                       ).element,
                     )
                   } else if (
-                    !this.paymentConfig.showStatusMessage &&
+                    !this.shouldShowStatusMessage() &&
                     !this.paymentConfig.invoiceDetails.return_url
                   ) {
                     this.resetContainerHtml().appendChild(
@@ -358,13 +377,13 @@ module ProcessOut {
                   tab_closed: error.metadata?.reason === "tab_closed",
                 })
               } else {
-                if (this.paymentConfig.showStatusMessage) {
+                if (this.shouldShowStatusMessage()) {
                   this.resetContainerHtml().appendChild(
                     new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
                       .element,
                   )
                 } else if (
-                  !this.paymentConfig.showStatusMessage &&
+                  !this.shouldShowStatusMessage() &&
                   !this.paymentConfig.invoiceDetails.return_url
                 ) {
                   this.resetContainerHtml().appendChild(
@@ -388,15 +407,12 @@ module ProcessOut {
           )
         },
         error => {
-          if (this.paymentConfig.showStatusMessage) {
+          if (this.shouldShowStatusMessage()) {
             this.resetContainerHtml().appendChild(
               new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
                 .element,
             )
-          } else if (
-            !this.paymentConfig.showStatusMessage &&
-            !this.paymentConfig.invoiceDetails.return_url
-          ) {
+          } else if (!this.shouldShowStatusMessage() && !this.paymentConfig.invoiceDetails.return_url) {
             this.resetContainerHtml().appendChild(
               new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig)
                 .element,
@@ -422,8 +438,11 @@ module ProcessOut {
         name: "save-apm-for-future",
         id: `save-apm-for-future-${this.paymentMethod.apm.gateway_name}`,
       }
+      const methodOptions = this.getMethodOptions()
+      const textOverrides = this.getTextOverrides()
+      const theme = this.getMethodTheme()
 
-      if (this.paymentConfig.enforceSavePaymentMethod) {
+      if (methodOptions.enforceSavePaymentMethod) {
         saveForFutureAttributes.checked = "checked"
         saveForFutureAttributes.disabled = "disabled"
       }
@@ -482,7 +501,7 @@ module ProcessOut {
           tagName: "button",
           classNames: ["dco-payment-method-button-pay-button"],
           textContent:
-            this.paymentConfig.payButtonText ||
+            textOverrides.payButtonText ||
             `${Translations.getText(
               "continue-with-apm-button",
               this.paymentConfig.locale,
@@ -501,12 +520,12 @@ module ProcessOut {
 
       HTMLElements.appendChildren(childrenWrapper, children)
 
-      if (this.theme && this.theme.payButtonColor) {
-        payButton.style.backgroundColor = this.theme.payButtonColor
+      if (theme && theme.payButtonColor) {
+        payButton.style.backgroundColor = theme.payButtonColor
       }
 
-      if (this.theme && this.theme.payButtonTextColor) {
-        payButton.style.color = this.theme.payButtonTextColor
+      if (theme && theme.payButtonTextColor) {
+        payButton.style.color = theme.payButtonTextColor
       }
 
       payButton.addEventListener("click", () => {

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -5,7 +5,6 @@ module ProcessOut {
     private procesoutInstance: ProcessOut
     private paymentMethod: PaymentMethod
     private paymentConfig: DynamicCheckoutPaymentConfig
-    private theme: DynamicCheckoutThemeType
     private resetContainerHtml: () => HTMLElement
     private isCardRestricted: boolean = false
     private tokenizedCardId?: string
@@ -14,7 +13,6 @@ module ProcessOut {
       procesoutInstance: ProcessOut,
       paymentMethod: PaymentMethod,
       paymentConfig: DynamicCheckoutPaymentConfig,
-      theme: DynamicCheckoutThemeType,
       resetContainerHtml: () => HTMLElement,
     ) {
       const { display } = paymentMethod
@@ -35,13 +33,24 @@ module ProcessOut {
       this.procesoutInstance = procesoutInstance
       this.paymentMethod = paymentMethod
       this.paymentConfig = paymentConfig
-      this.theme = theme
       this.resetContainerHtml = resetContainerHtml
 
       const cardForm = this.getChildrenElement()
 
       super.appendChildren(cardForm)
       this.setupCardForm(cardForm)
+    }
+
+    private getMethodOptions() {
+      return this.paymentConfig.getOptionsForMethod("card")
+    }
+
+    private getMethodTheme() {
+      return this.paymentConfig.getThemeForMethod("card")
+    }
+
+    private getTextOverrides() {
+      return this.paymentConfig.getTextOverridesForMethod("card")
     }
 
     private setupCardForm(form: HTMLElement): void {
@@ -122,11 +131,12 @@ module ProcessOut {
     private handleTokenizeSuccess(cardToken: string) {
       this.tokenizedCardId = cardToken
       const canSavePaymentMethod = this.paymentMethod.card.saving_allowed
+      const methodOptions = this.getMethodOptions()
 
       const cardPaymentOptions = {
-        authorize_only: !this.paymentConfig.capturePayments,
-        allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
-        save_source: canSavePaymentMethod && this.paymentConfig.enforceSavePaymentMethod,
+        authorize_only: !methodOptions.capturePayments,
+        allow_fallback_to_sale: methodOptions.allowFallbackToSale,
+        save_source: canSavePaymentMethod && methodOptions.enforceSavePaymentMethod,
       }
 
       const saveForFutureCheckbox = document.getElementById(
@@ -136,7 +146,7 @@ module ProcessOut {
       if (
         canSavePaymentMethod &&
         saveForFutureCheckbox &&
-        !this.paymentConfig.enforceSavePaymentMethod
+        !methodOptions.enforceSavePaymentMethod
       ) {
         cardPaymentOptions["save_source"] = saveForFutureCheckbox.checked
       }
@@ -169,6 +179,8 @@ module ProcessOut {
     }
 
     private handleCardPaymentSuccess(invoiceId: string, data?: any) {
+      const methodOptions = this.getMethodOptions()
+
       DynamicCheckoutEventsUtils.dispatchPaymentSuccessEvent({
         invoice_id: invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
@@ -177,14 +189,11 @@ module ProcessOut {
         customer_token_id: data?.customer_token_id,
       })
 
-      if (this.paymentConfig.showStatusMessage) {
+      if (methodOptions.showStatusMessage) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentSuccessView(this.procesoutInstance, this.paymentConfig).element,
         )
-      } else if (
-        !this.paymentConfig.showStatusMessage &&
-        !this.paymentConfig.invoiceDetails.return_url
-      ) {
+      } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig).element,
         )
@@ -192,7 +201,7 @@ module ProcessOut {
     }
 
     private handleCardPaymentPending(invoiceId: string) {
-      if (this.paymentConfig.showStatusMessage) {
+      if (this.getMethodOptions().showStatusMessage) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentPendingView(this.procesoutInstance, this.paymentConfig).element,
         )
@@ -207,14 +216,13 @@ module ProcessOut {
     }
 
     private handleCardPaymentError(error) {
-      if (this.paymentConfig.showStatusMessage) {
+      const methodOptions = this.getMethodOptions()
+
+      if (methodOptions.showStatusMessage) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentErrorView(this.procesoutInstance, this.paymentConfig).element,
         )
-      } else if (
-        !this.paymentConfig.showStatusMessage &&
-        !this.paymentConfig.invoiceDetails.return_url
-      ) {
+      } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig).element,
         )
@@ -276,13 +284,17 @@ module ProcessOut {
         name: "save-card-for-future",
       }
 
-      if (this.paymentConfig.enforceSavePaymentMethod) {
+      const methodOptions = this.getMethodOptions()
+      const textOverrides = this.getTextOverrides()
+      const theme = this.getMethodTheme()
+
+      if (methodOptions.enforceSavePaymentMethod) {
         saveForFutureAttributes.checked = "checked"
         saveForFutureAttributes.disabled = "disabled"
       }
 
       const payButtonText =
-        this.paymentConfig.payButtonText ||
+        textOverrides.payButtonText ||
         `${Translations.getText(
           "pay-button-text",
           this.paymentConfig.locale,
@@ -335,12 +347,12 @@ module ProcessOut {
         },
       ])
 
-      if (this.theme && this.theme.payButtonColor) {
-        payButton.style.backgroundColor = this.theme.payButtonColor
+      if (theme && theme.payButtonColor) {
+        payButton.style.backgroundColor = theme.payButtonColor
       }
 
-      if (this.theme && this.theme.payButtonTextColor) {
-        payButton.style.color = this.theme.payButtonTextColor
+      if (theme && theme.payButtonTextColor) {
+        payButton.style.color = theme.payButtonTextColor
       }
 
       HTMLElements.appendChildren(saveForFutureWrapper, [saveForFutureCheckbox, saveForFutureLabel])
@@ -364,14 +376,18 @@ module ProcessOut {
     }
 
     private getCvcLabel() {
+      const textOverrides = this.getTextOverrides()
+
       return (
-        this.paymentConfig.cvcLabel || Translations.getText("cvc-label", this.paymentConfig.locale)
+        textOverrides.cvcLabel || Translations.getText("cvc-label", this.paymentConfig.locale)
       )
     }
 
     private getCvcPlaceholder() {
+      const textOverrides = this.getTextOverrides()
+
       return (
-        this.paymentConfig.cvcPlaceholder ||
+        textOverrides.cvcPlaceholder ||
         Translations.getText("cvc-placeholder", this.paymentConfig.locale)
       )
     }

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -135,8 +135,8 @@ module ProcessOut {
 
       const cardPaymentOptions = {
         authorize_only: !methodOptions.capturePayments,
-        allow_fallback_to_sale: methodOptions.allowFallbackToSale,
-        save_source: canSavePaymentMethod && methodOptions.enforceSavePaymentMethod,
+        allow_fallback_to_sale: !!methodOptions.allowFallbackToSale,
+        save_source: canSavePaymentMethod && !!methodOptions.enforceSavePaymentMethod,
       }
 
       const saveForFutureCheckbox = document.getElementById(

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -2,6 +2,8 @@
 
 module ProcessOut {
   export class CardPaymentMethod extends PaymentMethodButton {
+    private static readonly METHOD_KEY = "card"
+
     private procesoutInstance: ProcessOut
     private paymentMethod: PaymentMethod
     private paymentConfig: DynamicCheckoutPaymentConfig
@@ -42,15 +44,15 @@ module ProcessOut {
     }
 
     private getMethodOptions() {
-      return this.paymentConfig.getOptionsForMethod("card")
+      return this.paymentConfig.getOptionsForMethod(CardPaymentMethod.METHOD_KEY)
     }
 
     private getMethodTheme() {
-      return this.paymentConfig.getThemeForMethod("card")
+      return this.paymentConfig.getThemeForMethod(CardPaymentMethod.METHOD_KEY)
     }
 
     private getTextOverrides() {
-      return this.paymentConfig.getTextOverridesForMethod("card")
+      return this.paymentConfig.getTextOverridesForMethod(CardPaymentMethod.METHOD_KEY)
     }
 
     private setupCardForm(form: HTMLElement): void {

--- a/src/dynamic-checkout/payment-methods/native-apm.ts
+++ b/src/dynamic-checkout/payment-methods/native-apm.ts
@@ -8,7 +8,6 @@ module ProcessOut {
     private paymentConfig: DynamicCheckoutPaymentConfig
     private isMounted: boolean
     private paymentMethodName: string
-    private theme: DynamicCheckoutThemeType
     private resetContainerHtml: () => HTMLElement
     protected processOutInstance: ProcessOut
 
@@ -18,7 +17,6 @@ module ProcessOut {
       processOutInstance: ProcessOut,
       paymentMethod: PaymentMethod,
       paymentConfig: DynamicCheckoutPaymentConfig,
-      theme: DynamicCheckoutThemeType,
       resetContainerHtml: () => HTMLElement,
       onPaymentSubmit?: () => void,
     ) {
@@ -31,25 +29,25 @@ module ProcessOut {
       this.paymentMethodName = apm.gateway_name
       this.processOutInstance = processOutInstance
       this.resetContainerHtml = resetContainerHtml
-      this.theme = theme
       this.onPaymentSubmit = onPaymentSubmit
 
       const wrapper = this.getNativeApmWrapper()
       super.appendChildren(wrapper)
+      const theme = this.paymentConfig.getThemeForMethod(this.paymentMethodName)
+      const textOverrides = this.paymentConfig.getTextOverridesForMethod(this.paymentMethodName)
 
       this.nativeApmInstance = this.processOutInstance.setupNativeApm({
         invoiceId,
         gatewayConfigurationId: apm.gateway_configuration_id,
         returnUrl: invoiceDetails.return_url,
-        payButtonText: paymentConfig.payButtonText,
+        payButtonText: textOverrides.payButtonText,
         locale: paymentConfig.locale,
       })
 
       const backgroundColor =
-        this.theme && this.theme.payButtonColor ? this.theme.payButtonColor : "#242C38"
+        theme && theme.payButtonColor ? theme.payButtonColor : "#242C38"
 
-      const color =
-        this.theme && this.theme.payButtonTextColor ? this.theme.payButtonTextColor : "white"
+      const color = theme && theme.payButtonTextColor ? theme.payButtonTextColor : "white"
 
       this.nativeApmInstance.setTheme({
         buttons: {
@@ -89,13 +87,13 @@ module ProcessOut {
           return
         }
 
-        if (this.paymentConfig.showStatusMessage) {
+        if (this.paymentConfig.getOptionsForMethod(this.paymentMethodName).showStatusMessage) {
           this.resetContainerHtml().appendChild(
             new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
               .element,
           )
         } else if (
-          !this.paymentConfig.showStatusMessage &&
+          !this.paymentConfig.getOptionsForMethod(this.paymentMethodName).showStatusMessage &&
           !this.paymentConfig.invoiceDetails.return_url
         ) {
           this.resetContainerHtml().appendChild(
@@ -117,13 +115,13 @@ module ProcessOut {
           return
         }
 
-        if (this.paymentConfig.showStatusMessage) {
+        if (this.paymentConfig.getOptionsForMethod(this.paymentMethodName).showStatusMessage) {
           this.resetContainerHtml().appendChild(
             new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
               .element,
           )
         } else if (
-          !this.paymentConfig.showStatusMessage &&
+          !this.paymentConfig.getOptionsForMethod(this.paymentMethodName).showStatusMessage &&
           !this.paymentConfig.invoiceDetails.return_url
         ) {
           this.resetContainerHtml().appendChild(

--- a/src/dynamic-checkout/payment-methods/saved-apm.ts
+++ b/src/dynamic-checkout/payment-methods/saved-apm.ts
@@ -11,7 +11,6 @@ module ProcessOut {
       processOutInstance: ProcessOut,
       paymentMethod: PaymentMethod,
       paymentConfig: DynamicCheckoutPaymentConfig,
-      theme: DynamicCheckoutThemeType,
       resetContainerHtml: () => HTMLElement,
       deleteMode?: boolean,
       handleDeletePaymentMethod?: () => void,
@@ -39,12 +38,14 @@ module ProcessOut {
     }
 
     private handleApmPayment() {
-      const { apm_customer_token, apm } = this.paymentMethod
+      const { apm_customer_token } = this.paymentMethod
       const { clientSecret, invoiceId } = this.paymentConfig
+      const methodKey = apm_customer_token.gateway_name
+      const methodOptions = this.paymentConfig.getOptionsForMethod(methodKey)
 
       const cardPaymentOptions = {
-        authorize_only: !this.paymentConfig.capturePayments,
-        allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
+        authorize_only: !methodOptions.capturePayments,
+        allow_fallback_to_sale: !!methodOptions.allowFallbackToSale,
       }
 
       const requestOptions = {
@@ -59,9 +60,7 @@ module ProcessOut {
       this.setLoading(this.paymentConfig.locale)
 
       if (apm_customer_token.redirect_url) {
-        const additionalData = this.paymentConfig.getAdditionalDataForGateway(
-          apm_customer_token.gateway_name,
-        )
+        const additionalData = this.paymentConfig.getAdditionalDataForMethod(methodKey)
 
         const redirectUrl = Object.keys(additionalData).length > 0
           ? this.processOutInstance.appendAdditionalDataToUrl(
@@ -85,17 +84,14 @@ module ProcessOut {
               paymentToken,
               cardPaymentOptions,
               invoiceId => {
-                if (this.paymentConfig.showStatusMessage) {
+                if (methodOptions.showStatusMessage) {
                   this.resetContainerHtml().appendChild(
                     new DynamicCheckoutPaymentSuccessView(
                       this.processOutInstance,
                       this.paymentConfig,
                     ).element,
                   )
-                } else if (
-                  !this.paymentConfig.showStatusMessage &&
-                  !this.paymentConfig.invoiceDetails.return_url
-                ) {
+                } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
                   this.resetContainerHtml().appendChild(
                     new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig)
                       .element,
@@ -109,15 +105,12 @@ module ProcessOut {
                 })
               },
               error => {
-                if (this.paymentConfig.showStatusMessage) {
+                if (methodOptions.showStatusMessage) {
                   this.resetContainerHtml().appendChild(
                     new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
                       .element,
                   )
-                } else if (
-                  !this.paymentConfig.showStatusMessage &&
-                  !this.paymentConfig.invoiceDetails.return_url
-                ) {
+                } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
                   this.resetContainerHtml().appendChild(
                     new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig)
                       .element,
@@ -134,7 +127,7 @@ module ProcessOut {
               },
               requestOptions,
               invoiceId => {
-                if (this.paymentConfig.showStatusMessage) {
+                if (methodOptions.showStatusMessage) {
                   this.resetContainerHtml().appendChild(
                     new DynamicCheckoutPaymentPendingView(
                       this.processOutInstance,
@@ -206,10 +199,22 @@ module ProcessOut {
       )
     }
 
-    private handlePaymentSuccess(invoiceId: string, data) {
-      this.resetContainerHtml().appendChild(
-        new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig).element,
-      )
+    private handlePaymentSuccess(invoiceId: string) {
+      const methodKey = this.paymentMethod.apm_customer_token
+        ? this.paymentMethod.apm_customer_token.gateway_name
+        : "apm"
+      const methodOptions = this.paymentConfig.getOptionsForMethod(methodKey)
+
+      if (methodOptions.showStatusMessage) {
+        this.resetContainerHtml().appendChild(
+          new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
+            .element,
+        )
+      } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
+        this.resetContainerHtml().appendChild(
+          new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig).element,
+        )
+      }
 
       DynamicCheckoutEventsUtils.dispatchPaymentSuccessEvent({
         invoice_id: invoiceId,
@@ -221,7 +226,12 @@ module ProcessOut {
     }
 
     private handlePaymentPending(invoiceId: string) {
-      if (this.paymentConfig.showStatusMessage) {
+      const methodKey = this.paymentMethod.apm_customer_token
+        ? this.paymentMethod.apm_customer_token.gateway_name
+        : "apm"
+      const methodOptions = this.paymentConfig.getOptionsForMethod(methodKey)
+
+      if (methodOptions.showStatusMessage) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentPendingView(this.processOutInstance, this.paymentConfig)
             .element,
@@ -238,6 +248,11 @@ module ProcessOut {
     }
 
     private handlePaymentError(error) {
+      const methodKey = this.paymentMethod.apm_customer_token
+        ? this.paymentMethod.apm_customer_token.gateway_name
+        : "apm"
+      const methodOptions = this.paymentConfig.getOptionsForMethod(methodKey)
+
       if (error.code === "customer.canceled") {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentCancelledView(this.processOutInstance, this.paymentConfig)
@@ -253,9 +268,17 @@ module ProcessOut {
           tab_closed: error.metadata?.reason === "tab_closed",
         })
       } else {
-        this.resetContainerHtml().appendChild(
-          new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig).element,
-        )
+        if (methodOptions.showStatusMessage) {
+          this.resetContainerHtml().appendChild(
+            new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
+              .element,
+          )
+        } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
+          this.resetContainerHtml().appendChild(
+            new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig)
+              .element,
+          )
+        }
 
         DynamicCheckoutEventsUtils.dispatchPaymentErrorEvent(
           this.paymentConfig.invoiceId,

--- a/src/dynamic-checkout/payment-methods/saved-card.ts
+++ b/src/dynamic-checkout/payment-methods/saved-card.ts
@@ -11,7 +11,6 @@ module ProcessOut {
       processOutInstance: ProcessOut,
       paymentMethod: PaymentMethod,
       paymentConfig: DynamicCheckoutPaymentConfig,
-      theme: DynamicCheckoutThemeType,
       resetContainerHtml: () => HTMLElement,
       deleteMode?: boolean,
       handleDeletePaymentMethod?: () => void,
@@ -39,6 +38,8 @@ module ProcessOut {
     }
 
     private handlePayment() {
+      const methodOptions = this.paymentConfig.getOptionsForMethod("card")
+
       this.setLoading(this.paymentConfig.locale)
 
       DynamicCheckoutEventsUtils.dispatchPaymentSubmittedEvent({
@@ -52,8 +53,8 @@ module ProcessOut {
         this.paymentConfig.invoiceId,
         this.paymentMethod.card_customer_token.customer_token_id,
         {
-          authorize_only: !this.paymentConfig.capturePayments,
-          allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
+          authorize_only: !methodOptions.capturePayments,
+          allow_fallback_to_sale: !!methodOptions.allowFallbackToSale,
         },
         this.handlePaymentSuccess.bind(this),
         this.handlePaymentError.bind(this),
@@ -63,15 +64,14 @@ module ProcessOut {
     }
 
     private handlePaymentSuccess(invoiceId: string) {
-      if (this.paymentConfig.showStatusMessage) {
+      const methodOptions = this.paymentConfig.getOptionsForMethod("card")
+
+      if (methodOptions.showStatusMessage) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentSuccessView(this.processOutInstance, this.paymentConfig)
             .element,
         )
-      } else if (
-        !this.paymentConfig.showStatusMessage &&
-        !this.paymentConfig.invoiceDetails.return_url
-      ) {
+      } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig).element,
         )
@@ -85,7 +85,7 @@ module ProcessOut {
     }
 
     private handlePaymentPending(invoiceId: string) {
-      if (this.paymentConfig.showStatusMessage) {
+      if (this.paymentConfig.getOptionsForMethod("card").showStatusMessage) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentPendingView(this.processOutInstance, this.paymentConfig)
             .element,
@@ -100,6 +100,8 @@ module ProcessOut {
     }
 
     private handlePaymentError(error) {
+      const methodOptions = this.paymentConfig.getOptionsForMethod("card")
+
       if (error.code === "customer.canceled") {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentCancelledView(this.processOutInstance, this.paymentConfig)
@@ -113,15 +115,12 @@ module ProcessOut {
           tab_closed: error.metadata?.reason === "tab_closed",
         })
       } else {
-        if (this.paymentConfig.showStatusMessage) {
+        if (methodOptions.showStatusMessage) {
           this.resetContainerHtml().appendChild(
             new DynamicCheckoutPaymentErrorView(this.processOutInstance, this.paymentConfig)
               .element,
           )
-        } else if (
-          !this.paymentConfig.showStatusMessage &&
-          !this.paymentConfig.invoiceDetails.return_url
-        ) {
+        } else if (!methodOptions.showStatusMessage && !this.paymentConfig.invoiceDetails.return_url) {
           this.resetContainerHtml().appendChild(
             new DynamicCheckoutPaymentInfoView(this.processOutInstance, this.paymentConfig)
               .element,

--- a/src/dynamic-checkout/views/payment-methods.ts
+++ b/src/dynamic-checkout/views/payment-methods.ts
@@ -6,19 +6,16 @@ module ProcessOut {
     dynamicCheckout: DynamicCheckout
     paymentConfig: DynamicCheckoutPaymentConfig
     paymentMethodsManager: PaymentMethodsManager
-    theme: DynamicCheckoutThemeType
     element: HTMLElement
 
     constructor(
       dynamicCheckout: DynamicCheckout,
       processOutInstance: ProcessOut,
       paymentConfig: DynamicCheckoutPaymentConfig,
-      theme: DynamicCheckoutThemeType,
     ) {
       this.dynamicCheckout = dynamicCheckout
       this.processOutInstance = processOutInstance
       this.paymentConfig = paymentConfig
-      this.theme = theme
       this.element = this.createViewElement()
       this.loadTingleLibrary()
     }
@@ -278,7 +275,6 @@ module ProcessOut {
               this.processOutInstance,
               paymentMethod,
               this.paymentConfig,
-              this.theme,
               this.resetContainerHtml.bind(this),
               deleteMode,
               () => this.handleDeletePaymentMethod(paymentMethod),
@@ -291,7 +287,6 @@ module ProcessOut {
               this.processOutInstance,
               paymentMethod,
               this.paymentConfig,
-              this.theme,
               this.resetContainerHtml.bind(this),
               deleteMode,
               () => this.handleDeletePaymentMethod(paymentMethod),
@@ -305,14 +300,12 @@ module ProcessOut {
                   this.processOutInstance,
                   paymentMethod,
                   this.paymentConfig,
-                  this.theme,
                   this.resetContainerHtml.bind(this),
                 )
               : new NativeApmPaymentMethod(
                   this.processOutInstance,
                   paymentMethod,
                   this.paymentConfig,
-                  this.theme,
                   this.resetContainerHtml.bind(this),
                   () => {
                     DynamicCheckoutEventsUtils.dispatchPaymentSubmittedEvent({
@@ -330,7 +323,6 @@ module ProcessOut {
               this.processOutInstance,
               paymentMethod,
               this.paymentConfig,
-              this.theme,
               this.resetContainerHtml.bind(this),
             )
 

--- a/src/processout/processout.ts
+++ b/src/processout/processout.ts
@@ -540,8 +540,9 @@ module ProcessOut {
     }
 
     /**
-     * SetupDynamicCheckout creates a Dynamic Checkout instance
-     * @param {DynamicCheckoutConfigType} config
+     * @deprecated Use initDynamicCheckout instead
+     * @param {DynamicCheckoutPublicConfigType} config
+     * @param {DynamicCheckoutThemeType} theme
      * @return {DynamicCheckout}
      */
     public setupDynamicCheckout(
@@ -554,7 +555,31 @@ module ProcessOut {
           "You must instantiate ProcessOut.js with a valid project ID in order to use ProcessOut's Dynamic Checkout",
         )
 
-      return new DynamicCheckout(this, { ...config, projectId: this.projectID }, theme)
+      return new DynamicCheckout(
+        this,
+        normalizeDynamicCheckoutSetupConfig(
+          { ...config, projectId: this.projectID },
+          theme,
+        ),
+      )
+    }
+
+    /**
+     * Creates a Dynamic Checkout instance
+     * @param {DynamicCheckoutInitConfigType} config
+     * @return {DynamicCheckout}
+     */
+    public initDynamicCheckout(config: DynamicCheckoutInitConfigType): DynamicCheckout {
+      if (!this.projectID)
+        throw new Exception(
+          "default",
+          "You must instantiate ProcessOut.js with a valid project ID in order to use ProcessOut's Dynamic Checkout",
+        )
+
+      return new DynamicCheckout(
+        this,
+        normalizeDynamicCheckoutConfig({ ...config, projectId: this.projectID }),
+      )
     }
 
     /**


### PR DESCRIPTION
## Summary

Redesign `initDynamicCheckout` public config interface to eliminate `_global` nesting, improve naming, and support per-payment-method overrides via a flat-then-override pattern. Deprecate `setupDynamicCheckout`.

## Changes

- New `DynamicCheckoutInitConfigType` with flat top-level `options`, `theme`, `text` and a `paymentMethodOverrides` dictionary for per-method config
- `DynamicCheckoutPaymentMethodKey` union type for autocomplete on known method keys (`card`, `applepay`, `googlepay`) while allowing arbitrary gateway names
- New `normalizeDynamicCheckoutConfig()` maps the flat public shape into the internal `_global`-based `DynamicCheckoutMethodScopedConfig` structure — zero changes to downstream payment method code
- `setupDynamicCheckout` marked `@deprecated` with JSDoc
- Old types (`DynamicCheckoutPublicConfigType`, `DynamicCheckoutInitPublicConfigType`) and their normalizers marked `@deprecated`
- Existing example switched to `setupDynamicCheckout`, new `dynamic-checkout-init` example showcases `initDynamicCheckout`
- Both examples display a live "Code Example" preview reflecting current form config
- Restructured `payment-config.ts` with clear section headers (internal helpers → shared types → current API → deprecated API → normalization → runtime class)

## Additional Context

- Inspired by Stripe's flat appearance API and Adyen's `paymentMethodsConfiguration` pattern — simple cases stay flat, per-method overrides are opt-in
- Scope limited to public API + normalization layer; `DynamicCheckoutPaymentConfig` class internals unchanged
- All code compiles to ES5 via TypeScript (`target: "es5"`)
