### PR TITLE
chore: payment method display name for dc events + tokens fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.8.9",
+  "version": "1.9.0",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/dynamic-checkout/clients/apple-pay.ts
+++ b/src/dynamic-checkout/clients/apple-pay.ts
@@ -144,17 +144,19 @@ module ProcessOut {
       invoiceData: Invoice,
       getViewContainer: () => HTMLElement,
     ) {
-      const applePayPaymentMethodData = this.getApplePayPaymentMethodData(invoiceData)
-      const canSavePaymentMethod = applePayPaymentMethodData.saving_allowed
+      const cardPaymentOptions = {
+        authorize_only: !this.paymentConfig.capturePayments,
+        allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
+      }
+
+      if (this.paymentConfig.enforceSavePaymentMethod) {
+        cardPaymentOptions["save_source"] = true
+      }
 
       this.processOutInstance.makeCardPayment(
         invoiceData.id,
         cardToken,
-        {
-          authorize_only: !this.paymentConfig.capturePayments,
-          allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
-          save_source: canSavePaymentMethod && this.paymentConfig.enforceSavePaymentMethod,
-        },
+        cardPaymentOptions,
         invoiceId => {
           if (this.paymentConfig.showStatusMessage) {
             getViewContainer().appendChild(
@@ -204,7 +206,9 @@ module ProcessOut {
             this.getApplePayPaymentMethodName(invoiceData),
           )
         },
-        undefined,
+        {
+          clientSecret: this.paymentConfig.clientSecret,
+        },
         invoiceId => {
           if (this.paymentConfig.showStatusMessage) {
             getViewContainer().appendChild(

--- a/src/dynamic-checkout/clients/apple-pay.ts
+++ b/src/dynamic-checkout/clients/apple-pay.ts
@@ -81,12 +81,14 @@ module ProcessOut {
         () =>
           DynamicCheckoutEventsUtils.dispatchApplePayNewSessionEvent(
             this.paymentConfig.invoiceId,
+            this.getApplePayPaymentMethodName(invoiceData),
             this.paymentConfig.invoiceDetails.return_url || null,
           ),
         err =>
           DynamicCheckoutEventsUtils.dispatchApplePaySessionError(
             this.paymentConfig.invoiceId,
             err,
+            this.getApplePayPaymentMethodName(invoiceData),
             this.paymentConfig.invoiceDetails.return_url || null,
           ),
       )
@@ -94,6 +96,7 @@ module ProcessOut {
       session.onpaymentauthorizedPostprocess = () =>
         DynamicCheckoutEventsUtils.dispatchApplePayAuthorizedPostProcessEvent(
           this.paymentConfig.invoiceId,
+          this.getApplePayPaymentMethodName(invoiceData),
           this.paymentConfig.invoiceDetails.return_url || null,
         )
 
@@ -129,6 +132,8 @@ module ProcessOut {
             "apple_pay",
             undefined,
             this.paymentConfig.invoiceDetails.return_url || null,
+            undefined,
+            this.getApplePayPaymentMethodName(invoiceData),
           )
         },
       )
@@ -139,12 +144,16 @@ module ProcessOut {
       invoiceData: Invoice,
       getViewContainer: () => HTMLElement,
     ) {
+      const applePayPaymentMethodData = this.getApplePayPaymentMethodData(invoiceData)
+      const canSavePaymentMethod = applePayPaymentMethodData.saving_allowed
+
       this.processOutInstance.makeCardPayment(
         invoiceData.id,
         cardToken,
         {
           authorize_only: !this.paymentConfig.capturePayments,
           allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
+          save_source: canSavePaymentMethod && this.paymentConfig.enforceSavePaymentMethod,
         },
         invoiceId => {
           if (this.paymentConfig.showStatusMessage) {
@@ -166,6 +175,7 @@ module ProcessOut {
             invoice_id: invoiceId,
             return_url: this.paymentConfig.invoiceDetails.return_url || null,
             payment_method_name: "apple_pay",
+            payment_method_display_name: this.getApplePayPaymentMethodName(invoiceData),
           })
         },
         error => {
@@ -190,6 +200,8 @@ module ProcessOut {
             "apple_pay",
             undefined,
             this.paymentConfig.invoiceDetails.return_url || null,
+            undefined,
+            this.getApplePayPaymentMethodName(invoiceData),
           )
         },
         undefined,
@@ -203,6 +215,7 @@ module ProcessOut {
 
           DynamicCheckoutEventsUtils.dispatchPaymentPendingEvent({
             payment_method_name: "apple_pay",
+            payment_method_display_name: this.getApplePayPaymentMethodName(invoiceData),
             invoice_id: invoiceId,
             return_url: this.paymentConfig.invoiceDetails.return_url || null,
           })
@@ -220,6 +233,18 @@ module ProcessOut {
       })
 
       return applePayPaymentMethodData
+    }
+
+    private getApplePayPaymentMethodName(invoiceData: Invoice) {
+      let applePayPaymentMethodName = "Apple Pay"
+
+      invoiceData.payment_methods.forEach(method => {
+        if (method.type === "applepay" && method.display) {
+          applePayPaymentMethodName = method.display.name
+        }
+      })
+
+      return applePayPaymentMethodName
     }
   }
 }

--- a/src/dynamic-checkout/clients/google-pay.ts
+++ b/src/dynamic-checkout/clients/google-pay.ts
@@ -133,17 +133,19 @@ module ProcessOut {
             paymentToken,
             {},
             token => {
-              const googlePayMethod = this.getGooglePayMethodData(invoiceData)
-              const canSavePaymentMethod = googlePayMethod.googlepay.saving_allowed
+              const cardPaymentOptions = {
+                authorize_only: !this.paymentConfig.capturePayments,
+                allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
+              }
+
+              if (this.paymentConfig.enforceSavePaymentMethod) {
+                cardPaymentOptions["save_source"] = true
+              }
 
               this.processOutInstance.makeCardPayment(
                 invoiceData.id,
                 token,
-                {
-                  authorize_only: !this.paymentConfig.capturePayments,
-                  allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
-                  save_source: canSavePaymentMethod && this.paymentConfig.enforceSavePaymentMethod,
-                },
+                cardPaymentOptions,
                 invoiceId => {
                   if (this.paymentConfig.showStatusMessage) {
                     getViewContainer().appendChild(
@@ -201,11 +203,16 @@ module ProcessOut {
                     this.getGooglePayPaymentMethodName(invoiceData),
                   )
                 },
-                undefined,
+                {
+                  clientSecret: this.paymentConfig.clientSecret,
+                },
                 invoiceId => {
                   if (this.paymentConfig.showStatusMessage) {
                     getViewContainer().appendChild(
-                      new DynamicCheckoutPaymentPendingView(this.processOutInstance, this.paymentConfig).element,
+                      new DynamicCheckoutPaymentPendingView(
+                        this.processOutInstance,
+                        this.paymentConfig,
+                      ).element,
                     )
                   }
 
@@ -330,7 +337,9 @@ module ProcessOut {
     private getGooglePayPaymentMethodName(invoiceData: Invoice) {
       const googlePayMethod = this.getGooglePayMethodData(invoiceData)
 
-      return googlePayMethod && googlePayMethod.display ? googlePayMethod.display.name : "Google Pay"
+      return googlePayMethod && googlePayMethod.display
+        ? googlePayMethod.display.name
+        : "Google Pay"
     }
   }
 }

--- a/src/dynamic-checkout/clients/google-pay.ts
+++ b/src/dynamic-checkout/clients/google-pay.ts
@@ -114,6 +114,7 @@ module ProcessOut {
           DynamicCheckoutEventsUtils.dispatchGooglePayLoadError(
             error,
             this.paymentConfig.invoiceId,
+            this.getGooglePayPaymentMethodName(invoiceData),
             this.paymentConfig.invoiceDetails.return_url || null,
           ),
         )
@@ -132,12 +133,16 @@ module ProcessOut {
             paymentToken,
             {},
             token => {
+              const googlePayMethod = this.getGooglePayMethodData(invoiceData)
+              const canSavePaymentMethod = googlePayMethod.googlepay.saving_allowed
+
               this.processOutInstance.makeCardPayment(
                 invoiceData.id,
                 token,
                 {
                   authorize_only: !this.paymentConfig.capturePayments,
                   allow_fallback_to_sale: this.paymentConfig.allowFallbackToSale,
+                  save_source: canSavePaymentMethod && this.paymentConfig.enforceSavePaymentMethod,
                 },
                 invoiceId => {
                   if (this.paymentConfig.showStatusMessage) {
@@ -163,6 +168,7 @@ module ProcessOut {
                     invoice_id: invoiceId,
                     return_url: this.paymentConfig.invoiceDetails.return_url || null,
                     payment_method_name: "google_pay",
+                    payment_method_display_name: this.getGooglePayPaymentMethodName(invoiceData),
                   })
                 },
                 error => {
@@ -191,6 +197,8 @@ module ProcessOut {
                     "google_pay",
                     undefined,
                     this.paymentConfig.invoiceDetails.return_url || null,
+                    undefined,
+                    this.getGooglePayPaymentMethodName(invoiceData),
                   )
                 },
                 undefined,
@@ -203,6 +211,7 @@ module ProcessOut {
 
                   DynamicCheckoutEventsUtils.dispatchPaymentPendingEvent({
                     payment_method_name: "google_pay",
+                    payment_method_display_name: this.getGooglePayPaymentMethodName(invoiceData),
                     invoice_id: invoiceId,
                     return_url: this.paymentConfig.invoiceDetails.return_url || null,
                   })
@@ -223,6 +232,8 @@ module ProcessOut {
                 "google_pay",
                 undefined,
                 this.paymentConfig.invoiceDetails.return_url || null,
+                undefined,
+                this.getGooglePayPaymentMethodName(invoiceData),
               )
             },
           )
@@ -231,6 +242,7 @@ module ProcessOut {
           DynamicCheckoutEventsUtils.dispatchGooglePayLoadError(
             error,
             this.paymentConfig.invoiceId,
+            this.getGooglePayPaymentMethodName(invoiceData),
             this.paymentConfig.invoiceDetails.return_url || null,
           ),
         )
@@ -313,6 +325,12 @@ module ProcessOut {
       })
 
       return googlePayMethod
+    }
+
+    private getGooglePayPaymentMethodName(invoiceData: Invoice) {
+      const googlePayMethod = this.getGooglePayMethodData(invoiceData)
+
+      return googlePayMethod && googlePayMethod.display ? googlePayMethod.display.name : "Google Pay"
     }
   }
 }

--- a/src/dynamic-checkout/payment-methods/apm.ts
+++ b/src/dynamic-checkout/payment-methods/apm.ts
@@ -16,6 +16,7 @@ module ProcessOut {
     protected processOutInstance: ProcessOut
     private paymentConfig: DynamicCheckoutPaymentConfig
     private paymentMethod: PaymentMethod
+    private paymentMethodDisplayName: string
     private theme: DynamicCheckoutThemeType
     private resetContainerHtml: () => HTMLElement
 
@@ -36,6 +37,7 @@ module ProcessOut {
       this.processOutInstance = processOutInstance
       this.paymentConfig = paymentConfig
       this.paymentMethod = paymentMethod
+      this.paymentMethodDisplayName = paymentMethod.display.name
       this.theme = theme
       this.resetContainerHtml = resetContainerHtml
 
@@ -100,6 +102,7 @@ module ProcessOut {
 
       DynamicCheckoutEventsUtils.dispatchPaymentSubmittedEvent({
         payment_method_name: apm.gateway_name,
+        payment_method_display_name: this.paymentMethodDisplayName,
         invoice_id: this.paymentConfig.invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
       })
@@ -135,6 +138,7 @@ module ProcessOut {
                 invoice_id: invoiceId,
                 return_url: this.paymentConfig.invoiceDetails.return_url || null,
                 payment_method_name: apm.gateway_name,
+                payment_method_display_name: this.paymentMethodDisplayName,
               })
             },
             error => {
@@ -149,6 +153,8 @@ module ProcessOut {
                 apm.gateway_name,
                 undefined,
                 this.paymentConfig.invoiceDetails.return_url || null,
+                undefined,
+                this.paymentMethodDisplayName,
               )
             },
             requestOptions,
@@ -160,6 +166,7 @@ module ProcessOut {
 
               DynamicCheckoutEventsUtils.dispatchPaymentPendingEvent({
                 payment_method_name: apm.gateway_name,
+                payment_method_display_name: this.paymentMethodDisplayName,
                 invoice_id: invoiceId,
                 return_url: this.paymentConfig.invoiceDetails.return_url || null,
               })
@@ -175,6 +182,7 @@ module ProcessOut {
 
             DynamicCheckoutEventsUtils.dispatchPaymentCancelledEvent({
               payment_method_name: apm.gateway_name,
+              payment_method_display_name: this.paymentMethodDisplayName,
               invoice_id: this.paymentConfig.invoiceId,
               return_url: this.paymentConfig.invoiceDetails.return_url || null,
               tab_closed: error.metadata?.reason === "tab_closed",
@@ -191,6 +199,8 @@ module ProcessOut {
               apm.gateway_name,
               undefined,
               this.paymentConfig.invoiceDetails.return_url || null,
+              undefined,
+              this.paymentMethodDisplayName,
             )
           }
         },
@@ -213,6 +223,7 @@ module ProcessOut {
 
       DynamicCheckoutEventsUtils.dispatchPaymentSubmittedEvent({
         payment_method_name: apm.gateway_name,
+        payment_method_display_name: this.paymentMethodDisplayName,
         invoice_id: this.paymentConfig.invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
       })
@@ -237,6 +248,7 @@ module ProcessOut {
               undefined,
               this.paymentConfig.invoiceDetails.return_url || null,
               data.customer_token_id,
+              this.paymentMethodDisplayName,
             )
             return
           }
@@ -249,6 +261,7 @@ module ProcessOut {
 
             DynamicCheckoutEventsUtils.dispatchPaymentPendingEvent({
               payment_method_name: apm.gateway_name,
+              payment_method_display_name: this.paymentMethodDisplayName,
               invoice_id: this.paymentConfig.invoiceId,
               return_url: this.paymentConfig.invoiceDetails.return_url || null,
               customer_token_id: data.customer_token_id,
@@ -292,6 +305,7 @@ module ProcessOut {
                     invoice_id: invoiceId,
                     return_url: this.paymentConfig.invoiceDetails.return_url || null,
                     payment_method_name: apm.gateway_name,
+                    payment_method_display_name: this.paymentMethodDisplayName,
                     customer_token_id: data.customer_token_id,
                   })
                 },
@@ -322,6 +336,7 @@ module ProcessOut {
                     undefined,
                     this.paymentConfig.invoiceDetails.return_url || null,
                     data.customer_token_id,
+                    this.paymentMethodDisplayName,
                   )
                 },
                 requestOptions,
@@ -335,6 +350,7 @@ module ProcessOut {
 
                   DynamicCheckoutEventsUtils.dispatchPaymentPendingEvent({
                     payment_method_name: apm.gateway_name,
+                    payment_method_display_name: this.paymentMethodDisplayName,
                     invoice_id: invoiceId,
                     return_url: this.paymentConfig.invoiceDetails.return_url || null,
                     customer_token_id: data.customer_token_id,
@@ -353,6 +369,7 @@ module ProcessOut {
 
                 DynamicCheckoutEventsUtils.dispatchPaymentCancelledEvent({
                   payment_method_name: apm.gateway_name,
+                  payment_method_display_name: this.paymentMethodDisplayName,
                   invoice_id: this.paymentConfig.invoiceId,
                   return_url: this.paymentConfig.invoiceDetails.return_url || null,
                   tab_closed: error.metadata?.reason === "tab_closed",
@@ -380,6 +397,7 @@ module ProcessOut {
                   undefined,
                   this.paymentConfig.invoiceDetails.return_url || null,
                   data.customer_token_id,
+                  this.paymentMethodDisplayName,
                 )
               }
             },
@@ -409,6 +427,8 @@ module ProcessOut {
             apm.gateway_name,
             undefined,
             this.paymentConfig.invoiceDetails.return_url || null,
+            undefined,
+            this.paymentMethodDisplayName,
           )
         },
         0,

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -4,6 +4,7 @@ module ProcessOut {
   export class CardPaymentMethod extends PaymentMethodButton {
     private procesoutInstance: ProcessOut
     private paymentMethod: PaymentMethod
+    private paymentMethodDisplayName: string
     private paymentConfig: DynamicCheckoutPaymentConfig
     private theme: DynamicCheckoutThemeType
     private resetContainerHtml: () => HTMLElement
@@ -34,6 +35,7 @@ module ProcessOut {
 
       this.procesoutInstance = procesoutInstance
       this.paymentMethod = paymentMethod
+      this.paymentMethodDisplayName = display.name
       this.paymentConfig = paymentConfig
       this.theme = theme
       this.resetContainerHtml = resetContainerHtml
@@ -95,6 +97,7 @@ module ProcessOut {
 
               DynamicCheckoutEventsUtils.dispatchPaymentSubmittedEvent({
                 payment_method_name: "card",
+                payment_method_display_name: this.paymentMethodDisplayName,
                 invoice_id: this.paymentConfig.invoiceId,
                 return_url: this.paymentConfig.invoiceDetails.return_url || null,
               })
@@ -115,6 +118,8 @@ module ProcessOut {
             "card",
             undefined,
             this.paymentConfig.invoiceDetails.return_url || null,
+            undefined,
+            this.paymentMethodDisplayName,
           ),
       )
     }
@@ -165,6 +170,8 @@ module ProcessOut {
         "card",
         this.tokenizedCardId,
         this.paymentConfig.invoiceDetails.return_url || null,
+        undefined,
+        this.paymentMethodDisplayName,
       )
     }
 
@@ -173,6 +180,7 @@ module ProcessOut {
         invoice_id: invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
         payment_method_name: "card",
+        payment_method_display_name: this.paymentMethodDisplayName,
         ...(this.tokenizedCardId && { card_id: this.tokenizedCardId }),
         customer_token_id: data?.customer_token_id,
       })
@@ -200,6 +208,7 @@ module ProcessOut {
 
       DynamicCheckoutEventsUtils.dispatchPaymentPendingEvent({
         payment_method_name: "card",
+        payment_method_display_name: this.paymentMethodDisplayName,
         invoice_id: invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
         ...(this.tokenizedCardId && { card_id: this.tokenizedCardId }),
@@ -226,6 +235,8 @@ module ProcessOut {
         "card",
         this.tokenizedCardId,
         this.paymentConfig.invoiceDetails.return_url || null,
+        undefined,
+        this.paymentMethodDisplayName,
       )
     }
 

--- a/src/dynamic-checkout/payment-methods/native-apm.ts
+++ b/src/dynamic-checkout/payment-methods/native-apm.ts
@@ -8,6 +8,7 @@ module ProcessOut {
     private paymentConfig: DynamicCheckoutPaymentConfig
     private isMounted: boolean
     private paymentMethodName: string
+    private paymentMethodDisplayName: string
     private theme: DynamicCheckoutThemeType
     private resetContainerHtml: () => HTMLElement
     protected processOutInstance: ProcessOut
@@ -29,6 +30,7 @@ module ProcessOut {
 
       this.paymentConfig = paymentConfig
       this.paymentMethodName = apm.gateway_name
+      this.paymentMethodDisplayName = display.name
       this.processOutInstance = processOutInstance
       this.resetContainerHtml = resetContainerHtml
       this.theme = theme
@@ -107,6 +109,7 @@ module ProcessOut {
           invoice_id: this.paymentConfig.invoiceId,
           return_url: this.paymentConfig.invoiceDetails.return_url || null,
           payment_method_name: this.paymentMethodName,
+          payment_method_display_name: this.paymentMethodDisplayName,
         })
 
         NativeApmPaymentMethod.activePaymentMethod = null
@@ -137,6 +140,8 @@ module ProcessOut {
           this.paymentMethodName,
           undefined,
           this.paymentConfig.invoiceDetails.return_url || null,
+          undefined,
+          this.paymentMethodDisplayName,
         )
 
         NativeApmPaymentMethod.activePaymentMethod = null

--- a/src/dynamic-checkout/payment-methods/saved-apm.ts
+++ b/src/dynamic-checkout/payment-methods/saved-apm.ts
@@ -5,6 +5,7 @@ module ProcessOut {
     protected processOutInstance: ProcessOut
     private paymentConfig: DynamicCheckoutPaymentConfig
     private paymentMethod: PaymentMethod
+    private paymentMethodDisplayName: string
     private resetContainerHtml: () => HTMLElement
 
     constructor(
@@ -31,6 +32,7 @@ module ProcessOut {
       this.processOutInstance = processOutInstance
       this.paymentConfig = paymentConfig
       this.paymentMethod = paymentMethod
+      this.paymentMethodDisplayName = paymentMethod.display.name
       this.resetContainerHtml = resetContainerHtml
 
       if (!deleteMode) {
@@ -72,6 +74,7 @@ module ProcessOut {
 
         DynamicCheckoutEventsUtils.dispatchPaymentSubmittedEvent({
           payment_method_name: apm_customer_token.gateway_name,
+          payment_method_display_name: this.paymentMethodDisplayName,
           invoice_id: invoiceId,
           return_url: this.paymentConfig.invoiceDetails.return_url || null,
           customer_token_id: apm_customer_token.customer_token_id,
@@ -106,6 +109,7 @@ module ProcessOut {
                   invoice_id: invoiceId,
                   return_url: this.paymentConfig.invoiceDetails.return_url || null,
                   payment_method_name: apm_customer_token.gateway_name,
+                  payment_method_display_name: this.paymentMethodDisplayName,
                 })
               },
               error => {
@@ -130,6 +134,8 @@ module ProcessOut {
                   apm_customer_token.gateway_name,
                   undefined,
                   this.paymentConfig.invoiceDetails.return_url || null,
+                  undefined,
+                  this.paymentMethodDisplayName,
                 )
               },
               requestOptions,
@@ -145,6 +151,7 @@ module ProcessOut {
 
                 DynamicCheckoutEventsUtils.dispatchPaymentPendingEvent({
                   payment_method_name: apm_customer_token.gateway_name,
+                  payment_method_display_name: this.paymentMethodDisplayName,
                   invoice_id: invoiceId,
                   return_url: this.paymentConfig.invoiceDetails.return_url || null,
                 })
@@ -162,6 +169,7 @@ module ProcessOut {
 
               DynamicCheckoutEventsUtils.dispatchPaymentCancelledEvent({
                 payment_method_name: apm_customer_token.gateway_name,
+                payment_method_display_name: this.paymentMethodDisplayName,
                 invoice_id: this.paymentConfig.invoiceId,
                 return_url: this.paymentConfig.invoiceDetails.return_url || null,
                 tab_closed: error.metadata?.reason === "tab_closed",
@@ -178,6 +186,8 @@ module ProcessOut {
                 apm_customer_token.gateway_name,
                 undefined,
                 this.paymentConfig.invoiceDetails.return_url || null,
+                undefined,
+                this.paymentMethodDisplayName,
               )
             }
           },
@@ -190,6 +200,7 @@ module ProcessOut {
         payment_method_name: this.paymentMethod.apm_customer_token
           ? this.paymentMethod.apm_customer_token.gateway_name
           : "apm",
+        payment_method_display_name: this.paymentMethodDisplayName,
         invoice_id: invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
         customer_token_id: apm_customer_token.customer_token_id,
@@ -217,6 +228,7 @@ module ProcessOut {
         payment_method_name: this.paymentMethod.apm_customer_token
           ? this.paymentMethod.apm_customer_token.gateway_name
           : "apm",
+        payment_method_display_name: this.paymentMethodDisplayName,
       })
     }
 
@@ -232,6 +244,7 @@ module ProcessOut {
         payment_method_name: this.paymentMethod.apm_customer_token
           ? this.paymentMethod.apm_customer_token.gateway_name
           : "apm",
+        payment_method_display_name: this.paymentMethodDisplayName,
         invoice_id: this.paymentConfig.invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
       })
@@ -248,6 +261,7 @@ module ProcessOut {
           payment_method_name: this.paymentMethod.apm_customer_token
             ? this.paymentMethod.apm_customer_token.gateway_name
             : "apm",
+          payment_method_display_name: this.paymentMethodDisplayName,
           invoice_id: this.paymentConfig.invoiceId,
           return_url: this.paymentConfig.invoiceDetails.return_url || null,
           tab_closed: error.metadata?.reason === "tab_closed",
@@ -265,6 +279,8 @@ module ProcessOut {
             : "apm",
           undefined,
           this.paymentConfig.invoiceDetails.return_url || null,
+          undefined,
+          this.paymentMethodDisplayName,
         )
       }
     }

--- a/src/dynamic-checkout/payment-methods/saved-card.ts
+++ b/src/dynamic-checkout/payment-methods/saved-card.ts
@@ -5,6 +5,7 @@ module ProcessOut {
     protected processOutInstance: ProcessOut
     private paymentConfig: DynamicCheckoutPaymentConfig
     private paymentMethod: PaymentMethod
+    private paymentMethodDisplayName: string
     private resetContainerHtml: () => HTMLElement
 
     constructor(
@@ -31,6 +32,7 @@ module ProcessOut {
       this.processOutInstance = processOutInstance
       this.paymentConfig = paymentConfig
       this.paymentMethod = paymentMethod
+      this.paymentMethodDisplayName = paymentMethod.display.name
       this.resetContainerHtml = resetContainerHtml
 
       if (!deleteMode) {
@@ -43,6 +45,7 @@ module ProcessOut {
 
       DynamicCheckoutEventsUtils.dispatchPaymentSubmittedEvent({
         payment_method_name: "card",
+        payment_method_display_name: this.paymentMethodDisplayName,
         invoice_id: this.paymentConfig.invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
         customer_token_id: this.paymentMethod.card_customer_token.customer_token_id,
@@ -81,6 +84,7 @@ module ProcessOut {
         invoice_id: invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
         payment_method_name: "card",
+        payment_method_display_name: this.paymentMethodDisplayName,
       })
     }
 
@@ -94,6 +98,7 @@ module ProcessOut {
 
       DynamicCheckoutEventsUtils.dispatchPaymentPendingEvent({
         payment_method_name: "card",
+        payment_method_display_name: this.paymentMethodDisplayName,
         invoice_id: invoiceId,
         return_url: this.paymentConfig.invoiceDetails.return_url || null,
       })
@@ -108,6 +113,7 @@ module ProcessOut {
 
         DynamicCheckoutEventsUtils.dispatchPaymentCancelledEvent({
           payment_method_name: "card",
+          payment_method_display_name: this.paymentMethodDisplayName,
           invoice_id: this.paymentConfig.invoiceId,
           return_url: this.paymentConfig.invoiceDetails.return_url || null,
           tab_closed: error.metadata?.reason === "tab_closed",
@@ -134,6 +140,8 @@ module ProcessOut {
           "card",
           undefined,
           this.paymentConfig.invoiceDetails.return_url || null,
+          undefined,
+          this.paymentMethodDisplayName,
         )
       }
     }

--- a/src/dynamic-checkout/types/api.ts
+++ b/src/dynamic-checkout/types/api.ts
@@ -38,6 +38,7 @@ type GooglePay = {
   allow_credit_cards: boolean
   gateway: string
   gateway_merchant_id: string
+  saving_allowed: boolean
 }
 
 type ApplePay = {
@@ -45,6 +46,7 @@ type ApplePay = {
   country_code: string
   supported_networks: string[]
   merchant_capabilities: string[]
+  saving_allowed: boolean
 }
 
 type Display = {

--- a/src/dynamic-checkout/types/api.ts
+++ b/src/dynamic-checkout/types/api.ts
@@ -38,7 +38,6 @@ type GooglePay = {
   allow_credit_cards: boolean
   gateway: string
   gateway_merchant_id: string
-  saving_allowed: boolean
 }
 
 type ApplePay = {
@@ -46,7 +45,6 @@ type ApplePay = {
   country_code: string
   supported_networks: string[]
   merchant_capabilities: string[]
-  saving_allowed: boolean
 }
 
 type Display = {

--- a/src/dynamic-checkout/utils/events.ts
+++ b/src/dynamic-checkout/utils/events.ts
@@ -23,6 +23,7 @@ module ProcessOut {
 
   interface DynamicCheckoutEventDetail {
     payment_method_name: string | null
+    payment_method_display_name: string | null
     return_url: string | null
     card_id?: string
   }
@@ -52,6 +53,7 @@ module ProcessOut {
           ...errorData,
           invoice_id: invoiceId,
           payment_method_name: null,
+          payment_method_display_name: null,
           return_url: returnUrl,
         },
       )
@@ -63,6 +65,7 @@ module ProcessOut {
       const event = DynamicCheckoutEventsUtils.createEvent(DYNAMIC_CHECKOUT_EVENTS.WIDGET_LOADING, {
         invoice_id: invoiceId,
         payment_method_name: null,
+        payment_method_display_name: null,
         return_url: returnUrl,
       })
       return window.dispatchEvent(event)
@@ -71,6 +74,8 @@ module ProcessOut {
     static dispatchWidgetReadyEvent(invoiceId: string, returnUrl: string | null) {
       const event = DynamicCheckoutEventsUtils.createEvent(DYNAMIC_CHECKOUT_EVENTS.WIDGET_READY, {
         invoice_id: invoiceId,
+        payment_method_name: null,
+        payment_method_display_name: null,
         return_url: returnUrl,
       })
       return window.dispatchEvent(event)
@@ -82,6 +87,7 @@ module ProcessOut {
         {
           ...errorData,
           payment_method_name: null,
+          payment_method_display_name: null,
           return_url: returnUrl,
         },
       )
@@ -95,6 +101,7 @@ module ProcessOut {
       cardId?: string,
       returnUrl?: string | null,
       customerTokenId?: string,
+      paymentMethodDisplayName?: string,
     ) {
       const normalizedError = DynamicCheckoutEventsUtils.normalizePaymentError(
         invoiceId,
@@ -103,6 +110,7 @@ module ProcessOut {
         cardId,
         returnUrl || null,
         customerTokenId,
+        paymentMethodDisplayName || null,
       )
 
       // TODO: Temporary fix until we fix properly the field unavailable error
@@ -123,6 +131,7 @@ module ProcessOut {
         {
           ...response,
           payment_method_name: response.payment_method_name || null,
+          payment_method_display_name: response.payment_method_display_name || null,
           return_url: response.return_url || null,
         },
       )
@@ -130,12 +139,17 @@ module ProcessOut {
       return window.dispatchEvent(event)
     }
 
-    static dispatchApplePayNewSessionEvent(invoiceId: string, returnUrl: string | null) {
+    static dispatchApplePayNewSessionEvent(
+      invoiceId: string,
+      paymentMethodDisplayName: string,
+      returnUrl: string | null,
+    ) {
       const event = DynamicCheckoutEventsUtils.createEvent(
         DYNAMIC_CHECKOUT_EVENTS.APPLE_PAY_NEW_SESSION,
         {
           invoice_id: invoiceId,
           payment_method_name: "apple_pay",
+          payment_method_display_name: paymentMethodDisplayName,
           return_url: returnUrl,
         },
       )
@@ -143,12 +157,17 @@ module ProcessOut {
       return window.dispatchEvent(event)
     }
 
-    static dispatchApplePayAuthorizedPostProcessEvent(invoiceId: string, returnUrl: string | null) {
+    static dispatchApplePayAuthorizedPostProcessEvent(
+      invoiceId: string,
+      paymentMethodDisplayName: string,
+      returnUrl: string | null,
+    ) {
       const event = DynamicCheckoutEventsUtils.createEvent(
         DYNAMIC_CHECKOUT_EVENTS.APPLE_PAY_AUTHORIZED_POST_PROCESS,
         {
           invoice_id: invoiceId,
           payment_method_name: "apple_pay",
+          payment_method_display_name: paymentMethodDisplayName,
           return_url: returnUrl,
         },
       )
@@ -156,13 +175,19 @@ module ProcessOut {
       return window.dispatchEvent(event)
     }
 
-    static dispatchApplePaySessionError(invoiceId: string, err: any, returnUrl: string | null) {
+    static dispatchApplePaySessionError(
+      invoiceId: string,
+      err: any,
+      paymentMethodDisplayName: string,
+      returnUrl: string | null,
+    ) {
       const event = DynamicCheckoutEventsUtils.createEvent(
         DYNAMIC_CHECKOUT_EVENTS.APPLE_PAY_SESSION_ERROR,
         {
           ...err,
           invoice_id: invoiceId,
           payment_method_name: "apple_pay",
+          payment_method_display_name: paymentMethodDisplayName,
           return_url: returnUrl,
         },
       )
@@ -174,12 +199,14 @@ module ProcessOut {
       invoiceId: string,
       paymentMethodName: string | null,
       returnUrl: string | null,
+      paymentMethodDisplayName?: string | null,
     ) {
       const event = DynamicCheckoutEventsUtils.createEvent(
         DYNAMIC_CHECKOUT_EVENTS.DELETE_PAYMENT_METHOD,
         {
           invoice_id: invoiceId,
           payment_method_name: paymentMethodName,
+          payment_method_display_name: paymentMethodDisplayName || null,
           return_url: returnUrl,
         },
       )
@@ -192,6 +219,7 @@ module ProcessOut {
       err: any,
       paymentMethodName: string | null,
       returnUrl: string | null,
+      paymentMethodDisplayName?: string | null,
     ) {
       const event = DynamicCheckoutEventsUtils.createEvent(
         DYNAMIC_CHECKOUT_EVENTS.DELETE_PAYMENT_METHOD_ERROR,
@@ -199,6 +227,7 @@ module ProcessOut {
           ...err,
           invoice_id: invoiceId,
           payment_method_name: paymentMethodName,
+          payment_method_display_name: paymentMethodDisplayName || null,
           return_url: returnUrl,
         },
       )
@@ -206,7 +235,12 @@ module ProcessOut {
       return window.dispatchEvent(event)
     }
 
-    static dispatchGooglePayLoadError(errorData: any, invoiceId: string, returnUrl: string | null) {
+    static dispatchGooglePayLoadError(
+      errorData: any,
+      invoiceId: string,
+      paymentMethodDisplayName: string,
+      returnUrl: string | null,
+    ) {
       const event = DynamicCheckoutEventsUtils.createEvent(
         DYNAMIC_CHECKOUT_EVENTS.GOOGLE_PAY_LOAD_ERROR,
         {
@@ -214,6 +248,7 @@ module ProcessOut {
           invoice_id: invoiceId,
           return_url: returnUrl,
           payment_method_name: "google_pay",
+          payment_method_display_name: paymentMethodDisplayName,
         },
       )
 
@@ -222,6 +257,7 @@ module ProcessOut {
 
     static dispatchPaymentSubmittedEvent(details: {
       payment_method_name: string
+      payment_method_display_name: string
       invoice_id: string
       return_url: string | null
       customer_token_id?: string
@@ -236,6 +272,7 @@ module ProcessOut {
 
     static dispatchPaymentCancelledEvent(details: {
       payment_method_name: string
+      payment_method_display_name: string
       invoice_id: string
       return_url: string | null
       tab_closed?: boolean
@@ -250,6 +287,7 @@ module ProcessOut {
 
     static dispatchPaymentPendingEvent(details: {
       payment_method_name: string
+      payment_method_display_name: string
       invoice_id: string
       return_url: string | null
       customer_token_id?: string
@@ -277,6 +315,7 @@ module ProcessOut {
       cardId?: string,
       returnUrl?: string | null,
       customerTokenId?: string,
+      paymentMethodDisplayName?: string | null,
     ): DynamicCheckoutPaymentErrorEventDetail {
       const normalizedError = DynamicCheckoutEventsUtils.getEventDetail(errorData)
       const isObject = typeof normalizedError === "object" && normalizedError !== null
@@ -284,6 +323,7 @@ module ProcessOut {
       return {
         invoice_id: invoiceId,
         payment_method_name: paymentMethodName,
+        payment_method_display_name: paymentMethodDisplayName,
         return_url: returnUrl || null,
         ...(cardId && { card_id: cardId }),
         ...(customerTokenId && { customer_token_id: customerTokenId }),

--- a/src/dynamic-checkout/views/payment-methods.ts
+++ b/src/dynamic-checkout/views/payment-methods.ts
@@ -317,6 +317,7 @@ module ProcessOut {
                   () => {
                     DynamicCheckoutEventsUtils.dispatchPaymentSubmittedEvent({
                       payment_method_name: paymentMethod.apm.gateway_name,
+                      payment_method_display_name: paymentMethod.display.name,
                       invoice_id: this.paymentConfig.invoiceId,
                       return_url: this.paymentConfig.invoiceDetails.return_url || null,
                     })
@@ -411,6 +412,7 @@ module ProcessOut {
               data,
               isCardToken ? "card" : paymentMethod.apm.gateway_name,
               this.paymentConfig.invoiceDetails.return_url || null,
+              paymentMethod.display.name,
             )
             return
           }
@@ -420,6 +422,7 @@ module ProcessOut {
             this.paymentConfig.invoiceId,
             isCardToken ? "card" : paymentMethod.apm.gateway_name,
             this.paymentConfig.invoiceDetails.return_url || null,
+            paymentMethod.display.name,
           )
         },
         err => {
@@ -428,6 +431,7 @@ module ProcessOut {
             err,
             isCardToken ? "card" : paymentMethod.apm.gateway_name,
             this.paymentConfig.invoiceDetails.return_url || null,
+            paymentMethod.display.name,
           )
         },
         0,


### PR DESCRIPTION
## Summary

Adds `payment_method_display_name` to Dynamic Checkout browser event details while preserving the existing `payment_method_name` identifier values. Also ensures Apple Pay and Google Pay honor enforced saved payment method behavior by passing `save_source` when supported.

## Changes

- Adds `payment_method_display_name` to Dynamic Checkout event payloads for payment submitted, success, pending, cancelled, error, wallet load/session events, and saved payment method delete events.
- Keeps `payment_method_name` unchanged as the existing technical identifier, such as `card`, `apple_pay`, `google_pay`, or an APM gateway name.
- Uses payment method display labels from invoice configuration, with wallet fallbacks like `Apple Pay` and `Google Pay`.
- Adds `saving_allowed` to Apple Pay and Google Pay method types and passes `save_source` when `enforceSavePaymentMethod` is enabled.
- Bumps package version.

## Impact

Dynamic Checkout event consumers can now read a user-facing payment method label without parsing or mapping the existing technical `payment_method_name`. Existing consumers of `payment_method_name` should continue to work unchanged.

## Testing Plan

- `yarn lint`
- `yarn build`

Recommended manual check:
- Trigger Dynamic Checkout card, APM, saved method, Apple Pay, and Google Pay flows.
- Confirm event details include both `payment_method_name` and `payment_method_display_name`.
- Confirm `payment_method_name` remains backward-compatible and `payment_method_display_name` shows labels like `Card` or `Klarna`.