### PR TITLE
fix: do not rerender nAPM confirmation page when polling [POS-1633]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/apm/API.ts
+++ b/src/apm/API.ts
@@ -511,12 +511,8 @@ module ProcessOut {
               }
             }
 
-            // Return on first PENDING response OR when there are non-empty elements.
-            // Empty/absent elements on subsequent polls (e.g. gateway awaiting webhook) must NOT
-            // trigger a re-render — that would unmount the Pending view, wipe instructions/QR,
-            // and reset the countdown timer (see Pending.ts componentWillUnmount).
-            const hasElements = !!(apiResponse.elements && apiResponse.elements.length > 0);
-            const shouldReturn = !internalOptions.hasReturnedFirstPending || hasElements;
+            // Return on first PENDING response OR anytime there are elements
+            const shouldReturn = !internalOptions.hasReturnedFirstPending || apiResponse.elements;
             
             if (shouldReturn) {
               if (!internalOptions.hasReturnedFirstPending) {

--- a/src/apm/API.ts
+++ b/src/apm/API.ts
@@ -511,8 +511,12 @@ module ProcessOut {
               }
             }
 
-            // Return on first PENDING response OR anytime there are elements
-            const shouldReturn = !internalOptions.hasReturnedFirstPending || apiResponse.elements;
+            // Return on first PENDING response OR when there are non-empty elements.
+            // Empty/absent elements on subsequent polls (e.g. gateway awaiting webhook) must NOT
+            // trigger a re-render — that would unmount the Pending view, wipe instructions/QR,
+            // and reset the countdown timer (see Pending.ts componentWillUnmount).
+            const hasElements = !!(apiResponse.elements && apiResponse.elements.length > 0);
+            const shouldReturn = !internalOptions.hasReturnedFirstPending || hasElements;
             
             if (shouldReturn) {
               if (!internalOptions.hasReturnedFirstPending) {

--- a/src/apm/Page.ts
+++ b/src/apm/Page.ts
@@ -55,6 +55,7 @@ module ProcessOut {
       (request.bind(APIImpl) as APIRequest)({
         hasConfirmedPending,
         onSuccess: ({ elements, ...config }) => {
+          const previousState = this.state
           this.state = config.state
           callback && callback(null, this.state);
 
@@ -73,7 +74,15 @@ module ProcessOut {
           }
 
           if (config.state === 'PENDING') {
-            ContextImpl.context.page.render(APMViewPending, { elements, config })
+            // Only render on the transition INTO PENDING. Background polling responses
+            // (PENDING → PENDING) must not re-render — that would unmount the Pending view,
+            // wiping displayed instructions/QR codes and resetting the countdown timer (see
+            // Pending.ts componentWillUnmount removing pending.startTime). When the user
+            // confirms via "I have sent the payment", the existing view's startTimer drives
+            // its own setState to reflect the confirmed state, so no re-render is needed here.
+            if (previousState !== 'PENDING') {
+              ContextImpl.context.page.render(APMViewPending, { elements, config })
+            }
           }
         },
         onError: ({ elements, ...config }) => {

--- a/src/apm/Page.ts
+++ b/src/apm/Page.ts
@@ -77,9 +77,7 @@ module ProcessOut {
             // Only render on the transition INTO PENDING. Background polling responses
             // (PENDING → PENDING) must not re-render — that would unmount the Pending view,
             // wiping displayed instructions/QR codes and resetting the countdown timer (see
-            // Pending.ts componentWillUnmount removing pending.startTime). When the user
-            // confirms via "I have sent the payment", the existing view's startTimer drives
-            // its own setState to reflect the confirmed state, so no re-render is needed here.
+            // Pending.ts componentWillUnmount removing pending.startTime).
             if (previousState !== 'PENDING') {
               ContextImpl.context.page.render(APMViewPending, { elements, config })
             }


### PR DESCRIPTION
<!--- Ensure the title above contains the Jira issue name e.g PROCESS0UT-1 -->

## Description
<!--- Provide some context in regard to this PR. -->
When doing polling, in most cases returned responses are empty with pending state. If the initial response contained some data e.g. qr code and consequent polling responses were empty, the qr code disappeared after rerender. This PR sets the behavior that render for pending state happens only once. 

## Solution
<!--- Describe the solution/fix implemented in this PR. -->

## Demo
<!--- If applicable, provide a demo of the solution/fix implemented in this PR. -->

## Checklist

- [x] I bumped the version of the project using `yarn bump-version`
- [x] I have checked the code for any potential issues
- [x] I tested my changes in the browser

## Notes
<!--- Include any extra notes you may want the reviewer to know -->

## Jira Issue
<!--- Please attach a link to the Jira issue where possible. -->
