### PR TITLE
fix: fix expiry date input in dc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -970,6 +970,7 @@ module ProcessOut {
           break
         case "card.invalid-month":
         case "card.invalid-year":
+        case "card.invalid-date":
           const cardExpiryErrorMessage = document.getElementById("expiry-date-error-message")
 
           if (cardExpiryErrorMessage) {


### PR DESCRIPTION
## Summary

  Fix expiry date validation error not displaying in Dynamic Checkout. The
  `card.invalid-date` error code wasn't handled, so a fully invalid expiry date
  silently failed to surface its error message.

  ## Changes

  - Handle `card.invalid-date` alongside `card.invalid-month` /
  `card.invalid-year` in the card field error handler, so the expiry-date error
  message is shown.

  card.invalid-date falls through the same case block as the existing month/year
  errors, so it now targets the expiry-date-error-message element. Minimal,
  single-line change in src/dynamic-checkout/payment-methods/card.ts.