### PR TITLE
fix: fix amex card payments in dc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/dynamic-checkout/config/card-networks-map.ts
+++ b/src/dynamic-checkout/config/card-networks-map.ts
@@ -23,4 +23,16 @@ module ProcessOut {
     visa: "visa",
     vpay: "vpay",
   }
+
+  // The card field detects schemes via Card.getPossibleSchemes(), which uses
+  // hyphenated codes (e.g. "american-express"). The rest of the platform
+  // (dashboard restrict_to_schemes, router, api) uses space-separated values
+  // (e.g. "american express"). This maps the SDK's multi-word codes to their
+  // platform equivalents so scheme restrictions match. Only schemes whose two
+  // spellings differ need an entry; single-word schemes already align.
+  export const schemeRestrictionAliases: { [key: string]: string } = {
+    "american-express": "american express",
+    "union-pay": "china union pay",
+    "diners-club": "diners club",
+  }
 }

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -917,12 +917,24 @@ module ProcessOut {
         return
       }
 
+      // The backend matches schemes case-insensitively (EqualFold), so we
+      // lowercase the allowlist to mirror that behaviour.
+      const allowedSchemes = restrictToSchemes.map(function (scheme) {
+        return scheme.toLowerCase()
+      })
+
       var hasAllowedScheme = false
 
       schemes.forEach(function (scheme) {
-        if (restrictToSchemes.indexOf(scheme) !== -1) {
-          hasAllowedScheme = true
-        }
+        // Compare both the detected (hyphenated) code and its platform alias
+        // (space-separated), e.g. "american-express" and "american express".
+        const candidates = [scheme, schemeRestrictionAliases[scheme]]
+
+        candidates.forEach(function (candidate) {
+          if (candidate && allowedSchemes.indexOf(candidate.toLowerCase()) !== -1) {
+            hasAllowedScheme = true
+          }
+        })
       })
 
       this.setCardRestrictionState(!hasAllowedScheme)


### PR DESCRIPTION
## Summary

Fix Amex (and other multi-word scheme) card payments being incorrectly blocked in Dynamic Checkout when `restrict_to_schemes` is set.

## Changes

- Add `schemeRestrictionAliases` map translating the SDK's hyphenated scheme codes (`american-express`, `union-pay`, `diners-club`) to the platform's space-separated equivalents (`american express`, `china union pay`, `diners club`).
- In the card restriction check, match a detected scheme against both its hyphenated code and its platform alias, and compare case-insensitively to mirror the backend's `EqualFold` matching.

## Additional Context

- Root cause: `Card.getPossibleSchemes()` returns hyphenated codes, but `restrict_to_schemes` (dashboard/router/API) uses space-separated values, so multi-word schemes never matched and valid cards were rejected. Single-word schemes already align and need no alias.