### PR TITLE
fix: add rtl layout support to card form fields in dc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/dynamic-checkout/dynamic-checkout.ts
+++ b/src/dynamic-checkout/dynamic-checkout.ts
@@ -162,7 +162,7 @@ module ProcessOut {
       this.widgetWrapper = document.createElement("div")
       this.widgetWrapper.setAttribute("class", "dynamic-checkout-widget-wrapper")
 
-      if (this.paymentConfig.locale === "ar") {
+      if (Translations.isRtlLocale(this.paymentConfig.locale)) {
         this.widgetWrapper.setAttribute("dir", "rtl")
       }
 

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -268,6 +268,12 @@ module ProcessOut {
         fontSize: "14px",
       }
 
+      if (Translations.isRtlLocale(this.paymentConfig.locale)) {
+        // Hosted field iframes don't inherit the widget's dir="rtl",
+        // so the direction has to be passed to them explicitly
+        options.style.direction = "rtl"
+      }
+
       options.placeholder = ""
       options.expiryAutoNext = false
       options.cardNumberAutoNext = true

--- a/src/dynamic-checkout/styles/default.ts
+++ b/src/dynamic-checkout/styles/default.ts
@@ -937,7 +937,7 @@ const defaultStyles = `
   }
 
   .dynamic-checkout-widget-wrapper[dir="rtl"] .dco-payment-method-card-form-input-cvc {
-    padding-right: 0;
+    padding-right: 8px;
     padding-left: 40px;
   }
 

--- a/src/dynamic-checkout/utils/translations.ts
+++ b/src/dynamic-checkout/utils/translations.ts
@@ -19,11 +19,22 @@ module ProcessOut {
       vi: vi,
     }
 
+    static rtlLocales = ["ar"]
+
     static getText(key: string, locale: string) {
+      const language = Translations.getLanguageCode(locale)
       const keys =
-        Translations.localeTranslationsMap[locale] || Translations.localeTranslationsMap.en
+        Translations.localeTranslationsMap[language] || Translations.localeTranslationsMap.en
 
       return keys[key] || ""
+    }
+
+    static isRtlLocale(locale: string) {
+      return Translations.rtlLocales.indexOf(Translations.getLanguageCode(locale)) !== -1
+    }
+
+    static getLanguageCode(locale: string) {
+      return locale ? locale.toLowerCase().split(/[-_]/)[0] : ""
     }
   }
 }


### PR DESCRIPTION
## Summary

Arabic (RTL) locale in Dynamic Checkout rendered the card form inputs with left-aligned, LTR placeholders. The card number, expiry, and CVC fields are hosted iframes, so the widget's `dir="rtl"` never reached them.

## Changes

- Pass `direction: "rtl"` to the hosted card fields' style options for RTL locales — the field applies `text-align: right` (and true RTL only for CVC), so card number digits keep their order
- Add `Translations.isRtlLocale()` and reuse it for the existing `dir="rtl"` wrapper check instead of a hardcoded `"ar"` comparison
- Fix RTL CVC input padding: restore the base 8px on the text side (was 0, leaving the placeholder flush against the input edge)

## Additional Context

- Moving the in-iframe scheme selection logo to the left in RTL requires a `checkout-cdn` change (`body.rtl` handling in `ccfield.html`/`Field.ts`), shipped separately