### PR TITLE
chore(POCP-1226): support 8-digit IINs in card event

### DIFF
--- a/examples/card-form/index.html
+++ b/examples/card-form/index.html
@@ -55,7 +55,7 @@
           function (form) {
             let preferredCardType = null;
             form.getNumberField().on("input", function (e) {
-              if (e.card_number_length == 6) {
+              if (e.card_number_length == 8) {
                 client.getCardInformation(
                   e.card_iin,
                   function(cardInfo) {
@@ -65,7 +65,7 @@
                       const radioGroup = document.createElement('div')
                       radioGroup.className = 'combo-card-types'
                       radioGroup.style.cssText = 'margin: 15px 0; padding: 15px; border: 1px solid #ddd; border-radius: 5px; background: #f9f9f9;'
-                      
+
                       radioGroup.innerHTML = `
                         <h4 style="margin: 0 0 10px 0; color: #333;">Select Card Type:</h4>
                         ${cardInfo.combo_card_types.map((type, index) => `
@@ -75,11 +75,11 @@
                           </label>
                         `).join('')}
                       `
-                      
+
                       // Insert before the Pay button
                       const payButton = document.querySelector('.submit-button')
                       payButton.parentNode.insertBefore(radioGroup, payButton)
-                      
+
                       // Add event listener to track selection changes
                       const radioButtons = radioGroup.querySelectorAll('input[name="cardType"]')
                       radioButtons.forEach(radio => {
@@ -88,7 +88,7 @@
                           console.log("User selected card type:", preferredCardType)
                         })
                       })
-                      
+
                       // Set initial value
                       preferredCardType = null
                     }
@@ -98,7 +98,7 @@
                   }
                 )
               }
-    
+
               document.getElementById("errors").innerHTML = ""
             })
 

--- a/examples/card-form/index.html
+++ b/examples/card-form/index.html
@@ -55,9 +55,9 @@
           function (form) {
             let preferredCardType = null;
             form.getNumberField().on("input", function (e) {
-              if (e.card_number_length == 8) {
+              if (e.card_number_length == 6) {
                 client.getCardInformation(
-                  e.card_iin8,
+                  e.card_iin,
                   function(cardInfo) {
                     // Check for combo card types and display radio buttons if they exist
                     if (cardInfo.combo_card_types && Array.isArray(cardInfo.combo_card_types) && cardInfo.combo_card_types.length > 0) {

--- a/examples/card-form/index.html
+++ b/examples/card-form/index.html
@@ -57,7 +57,7 @@
             form.getNumberField().on("input", function (e) {
               if (e.card_number_length == 8) {
                 client.getCardInformation(
-                  e.card_iin,
+                  e.card_iin8,
                   function(cardInfo) {
                     // Check for combo card types and display radio buttons if they exist
                     if (cardInfo.combo_card_types && Array.isArray(cardInfo.combo_card_types) && cardInfo.combo_card_types.length > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -918,7 +918,12 @@ module ProcessOut {
         return
       }
 
-      const isAllowedIin = restrictToIins.indexOf(iin) !== -1
+      // card_iin may carry more digits than the configured entries (IINs can
+      // be 6 or 8 digits), so match on prefix: an allowed entry matches when
+      // the detected IIN starts with it.
+      const isAllowedIin = restrictToIins.some(function (allowedIin) {
+        return allowedIin.length > 0 && iin.substring(0, allowedIin.length) === allowedIin
+      })
 
       this.setCardRestrictionState(!isAllowedIin)
     }

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -646,7 +646,10 @@ module ProcessOut {
           const eventData = e.data ? JSON.parse(e.data) : {}
 
           if (eventData.action === "inputEvent") {
-            if (eventData.data && eventData.data.card_iin !== undefined) {
+            if (
+              eventData.data &&
+              (eventData.data.card_iin8 !== undefined || eventData.data.card_iin !== undefined)
+            ) {
               this.handleIinRestrictionFromMessage(eventData.data)
             }
 
@@ -911,14 +914,16 @@ module ProcessOut {
         return
       }
 
-      const iin = data.card_iin || ""
+      // Prefer the 8-digit IIN when present so 8-digit allowlist entries can
+      // match; fall back to the legacy 6-digit card_iin.
+      const iin = data.card_iin8 || data.card_iin || ""
 
       if (iin.length === 0) {
         this.setCardRestrictionState(false)
         return
       }
 
-      // card_iin may carry more digits than the configured entries (IINs can
+      // card_iin8 may carry more digits than the configured entries (IINs can
       // be 6 or 8 digits), so match on prefix: an allowed entry matches when
       // the detected IIN starts with it.
       const isAllowedIin = restrictToIins.some(function (allowedIin) {

--- a/src/processout/card.ts
+++ b/src/processout/card.ts
@@ -455,10 +455,45 @@ module ProcessOut {
         public static getIIN(number: string): string {
             number = Card.parseNumber(number); // Remove potential spaces
 
+            // Only expose an 8-digit IIN for schemes the backend allows to
+            // do so; every other scheme is capped at 6 to avoid
+            // over-exposing the BIN. Mirrors api (controllers/card_inn.go).
+            var max = Card.canExpose8DigitIIN(number) ? 8 : 6;
             var l = number.length;
-            if (l > 8)
-                l = 8;
+            if (l > max)
+                l = max;
             return number.substring(0, l);
+        }
+
+        /**
+         * Schemes permitted to surface an 8-digit IIN, mirroring the backend
+         * allow-list in api (controllers/card_inn.go). Every other scheme -
+         * notably American Express - is capped at 6 digits. Note the JS
+         * scheme key "union-pay" maps to the backend's "china union pay".
+         */
+        private static iin8DigitSchemes: Array<string> = [
+            "visa", "mastercard", "discover", "jcb", "union-pay", "carte bancaire"
+        ];
+
+        /**
+         * canExpose8DigitIIN reports whether the card number's detected
+         * scheme(s) are allowed to surface an 8-digit IIN. Conservative: every
+         * detected scheme must be in the allow-list, so co-badged or ambiguous
+         * prefixes (and unknown schemes) fall back to 6 digits.
+         * @param {string} number
+         * @return {boolean}
+         */
+        public static canExpose8DigitIIN(number: string): boolean {
+            var schemes = Card.getPossibleSchemes(number);
+            if (schemes.length == 0)
+                return false;
+
+            for (var i = 0; i < schemes.length; i++) {
+                if (Card.iin8DigitSchemes.indexOf(schemes[i]) === -1)
+                    return false;
+            }
+
+            return true;
         }
 
         /**

--- a/src/processout/card.ts
+++ b/src/processout/card.ts
@@ -455,14 +455,17 @@ module ProcessOut {
         public static getIIN(number: string): string {
             number = Card.parseNumber(number); // Remove potential spaces
 
-            // Only expose an 8-digit IIN for schemes the backend allows to
-            // do so; every other scheme is capped at 6 to avoid
-            // over-exposing the BIN. Mirrors api (controllers/card_inn.go).
-            var max = Card.canExpose8DigitIIN(number) ? 8 : 6;
-            var l = number.length;
-            if (l > max)
-                l = max;
-            return number.substring(0, l);
+            if (number.length < 6)
+                return number;
+
+            // Only expose an 8-digit IIN when PCI rules allow it: the scheme
+            // must permit it and the full PAN must be exactly 16 digits.
+            // Everything else caps at 6 to avoid over-exposing the BIN.
+            // Mirrors binder's TruncateNumber / api (controllers/card_inn.go).
+            if (Card.canExpose8DigitIIN(number))
+                return number.substring(0, 8);
+
+            return number.substring(0, 6);
         }
 
         /**
@@ -476,14 +479,21 @@ module ProcessOut {
         ];
 
         /**
-         * canExpose8DigitIIN reports whether the card number's detected
-         * scheme(s) are allowed to surface an 8-digit IIN. Conservative: every
-         * detected scheme must be in the allow-list, so co-badged or ambiguous
-         * prefixes (and unknown schemes) fall back to 6 digits.
+         * canExpose8DigitIIN reports whether an 8-digit IIN may be surfaced
+         * for the given card number. Mirrors binder's TruncateNumber: the PAN
+         * must be exactly 16 digits and every detected scheme must be in the
+         * allow-list. Conservative on co-badged or ambiguous prefixes (and
+         * unknown schemes), which fall back to 6 digits.
          * @param {string} number
          * @return {boolean}
          */
         public static canExpose8DigitIIN(number: string): boolean {
+            number = Card.parseNumber(number); // Remove potential spaces
+
+            // PCI: 8-digit BINs are only defined for 16-digit PANs.
+            if (number.length != 16)
+                return false;
+
             var schemes = Card.getPossibleSchemes(number);
             if (schemes.length == 0)
                 return false;

--- a/src/processout/card.ts
+++ b/src/processout/card.ts
@@ -456,8 +456,8 @@ module ProcessOut {
             number = Card.parseNumber(number); // Remove potential spaces
 
             var l = number.length;
-            if (l > 6)
-                l = 6;
+            if (l > 8)
+                l = 8;
             return number.substring(0, l);
         }
 

--- a/src/processout/card.ts
+++ b/src/processout/card.ts
@@ -455,13 +455,25 @@ module ProcessOut {
         public static getIIN(number: string): string {
             number = Card.parseNumber(number); // Remove potential spaces
 
+            var l = number.length;
+            if (l > 6)
+                l = 6;
+            return number.substring(0, l);
+        }
+
+        /**
+         * GetIIN8 returns the IIN of the card number, exposing up to 8 digits
+         * when PCI rules allow it (scheme in the allow-list and a 16-digit
+         * PAN) and 6 digits otherwise.
+         * @param {string} number
+         * @return {string}
+         */
+        public static getIIN8(number: string): string {
+            number = Card.parseNumber(number); // Remove potential spaces
+
             if (number.length < 6)
                 return number;
 
-            // Only expose an 8-digit IIN when PCI rules allow it: the scheme
-            // must permit it and the full PAN must be exactly 16 digits.
-            // Everything else caps at 6 to avoid over-exposing the BIN.
-            // Mirrors binder's TruncateNumber / api (controllers/card_inn.go).
             if (Card.canExpose8DigitIIN(number))
                 return number.substring(0, 8);
 

--- a/src/processout/processout.ts
+++ b/src/processout/processout.ts
@@ -1676,7 +1676,10 @@ module ProcessOut {
         return
       }
 
-      const iin = cardNumber.substring(0, 6)
+      // Support up to 8-digit IINs (some networks issue 8-digit IINs, which
+      // yield more accurate issuer information); fall back to whatever is
+      // available when fewer digits were provided.
+      const iin = cardNumber.substring(0, 8)
       const apiEndpoint = `iins/${iin}`
 
       this.apiRequest(


### PR DESCRIPTION
# Description

The PO.JS card event exposes a card's IIN capped at 6 digits (`card_iin`). Civitatis needs 8 digits to call MercadoPago's `GET /installments` directly. Rather than widening the existing field (a breaking change for merchants
expecting 6 digits), this adds a new 8-digit field alongside the untouched 6-digit one, letting merchants migrate at their own pace.

# Solution

- New `Card.getIIN8`: returns 8 digits only when the PAN is exactly 16 digits **and** the scheme is in the allow-list; Amex, non-16-digit PANs, unknown or co-badged/ambiguous prefixes fall back to 6 (never empty, so merchants need no empty-value fallback).
- `Card.getIIN` unchanged (still capped at 6). The legacy `card_iin` event field keeps its exact current behaviour -legacy merchants are unaffected.
- New `card_iin8` event field can be emitted from the card form's `getFieldData()` alongside `card_iin`.
- Dynamic Checkout IIN restriction (`restrict_to_iins`) now matches on `card_iin8` when present, falling back to `card_iin`, using prefix match so 6- or 8-digit allowlist entries both work.
- `getCardInformation` still passes up to 8 digits to the `iins/{iin}` lookup. Minimum-length guard (6) unchanged.

# Notes

- Requires the paired **checkout-cdn** PR to emit `card_iin8`.

# Checklist

- [x] I bumped the version of the project using yarn bump-version
- [x] I have checked the code for any potential issues
- [x] I tested my changes in the browser

# Jira Issue
[POCP-1226](https://checkout.atlassian.net/browse/POCP-1226)

[POCP-1226]: https://checkout.atlassian.net/browse/POCP-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ