### PR TITLE
fix: fix customer cancelled typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "processout.js",
-  "version": "1.9.10",
+  "version": "1.9.11",
   "description": "ProcessOut.js is a JavaScript library for ProcessOut's payment processing API.",
   "scripts": {
     "build:processout": "tsc -p src/processout && uglifyjs --compress --keep-fnames --ie8 dist/processout.js -o dist/processout.js",

--- a/src/dynamic-checkout/payment-methods/apm.ts
+++ b/src/dynamic-checkout/payment-methods/apm.ts
@@ -176,7 +176,7 @@ module ProcessOut {
           )
         },
         error => {
-          if (error.code === "customer.canceled") {
+          if (isCustomerCancellationError(error)) {
             this.resetContainerHtml().appendChild(
               new DynamicCheckoutPaymentCancelledView(this.processOutInstance, this.paymentConfig)
                 .element,
@@ -364,7 +364,7 @@ module ProcessOut {
               )
             },
             error => {
-              if (error.code === "customer.canceled") {
+              if (isCustomerCancellationError(error)) {
                 this.resetContainerHtml().appendChild(
                   new DynamicCheckoutPaymentCancelledView(
                     this.processOutInstance,

--- a/src/dynamic-checkout/payment-methods/card.ts
+++ b/src/dynamic-checkout/payment-methods/card.ts
@@ -220,7 +220,7 @@ module ProcessOut {
     }
 
     private handleCardPaymentError(error) {
-      if (error.code === "customer.canceled") {
+      if (isCustomerCancellationError(error)) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentCancelledView(this.processOutInstance, this.paymentConfig)
             .element,

--- a/src/dynamic-checkout/payment-methods/saved-apm.ts
+++ b/src/dynamic-checkout/payment-methods/saved-apm.ts
@@ -161,7 +161,7 @@ module ProcessOut {
             )
           },
           error => {
-            if (error.code === "customer.canceled") {
+            if (isCustomerCancellationError(error)) {
               this.resetContainerHtml().appendChild(
                 new DynamicCheckoutPaymentCancelledView(
                   this.processOutInstance,
@@ -255,7 +255,7 @@ module ProcessOut {
     }
 
     private handlePaymentError(error) {
-      if (error.code === "customer.canceled") {
+      if (isCustomerCancellationError(error)) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentCancelledView(this.processOutInstance, this.paymentConfig)
             .element,

--- a/src/dynamic-checkout/payment-methods/saved-card.ts
+++ b/src/dynamic-checkout/payment-methods/saved-card.ts
@@ -107,7 +107,7 @@ module ProcessOut {
     }
 
     private handlePaymentError(error) {
-      if (error.code === "customer.canceled") {
+      if (isCustomerCancellationError(error)) {
         this.resetContainerHtml().appendChild(
           new DynamicCheckoutPaymentCancelledView(this.processOutInstance, this.paymentConfig)
             .element,

--- a/src/dynamic-checkout/references.ts
+++ b/src/dynamic-checkout/references.ts
@@ -38,6 +38,7 @@
 /// <reference path="locales/pt.ts" />
 /// <reference path="locales/ta.ts" />
 /// <reference path="locales/vi.ts" />
+/// <reference path="utils/errors.ts" />
 /// <reference path="utils/events.ts" />
 /// <reference path="utils/translations.ts" />
 /// <reference path="utils/elements.ts" />

--- a/src/dynamic-checkout/utils/errors.ts
+++ b/src/dynamic-checkout/utils/errors.ts
@@ -1,0 +1,11 @@
+/// <reference path="../references.ts" />
+
+module ProcessOut {
+  // The SDK raises "customer.canceled" for cancellations it detects itself
+  // (overlay cancel, tab/window closed), while cancellations that happen on a
+  // gateway's hosted page come back from the API as "customer.cancelled".
+  // Both must be treated as a customer cancellation.
+  export function isCustomerCancellationError(error: { code?: string }): boolean {
+    return error.code === "customer.canceled" || error.code === "customer.cancelled"
+  }
+}

--- a/test/dynamic-checkout/errors.test.ts
+++ b/test/dynamic-checkout/errors.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { loadNamespaceFile } from "../support/loadNamespace"
+
+const { isCustomerCancellationError } = loadNamespaceFile("src/dynamic-checkout/utils/errors.ts")
+
+describe("isCustomerCancellationError", () => {
+  it("matches the SDK-internal cancellation code", () => {
+    expect(isCustomerCancellationError({ code: "customer.canceled" })).toBe(true)
+  })
+
+  it("matches the API cancellation code raised by gateway-hosted pages", () => {
+    expect(isCustomerCancellationError({ code: "customer.cancelled" })).toBe(true)
+  })
+
+  it("rejects other error codes", () => {
+    expect(isCustomerCancellationError({ code: "customer.popup-blocked" })).toBe(false)
+    expect(isCustomerCancellationError({ code: "card.declined" })).toBe(false)
+    expect(isCustomerCancellationError({})).toBe(false)
+  })
+})

--- a/test/support/loadNamespace.ts
+++ b/test/support/loadNamespace.ts
@@ -56,3 +56,16 @@ export function loadApmUtils(navigator: FakeNavigator = {}): Record<string, any>
   run(moduleShim, moduleShim.exports, navigator)
   return moduleShim.exports
 }
+
+/**
+ * Load a self-contained namespace source file and return its `ProcessOut`
+ * namespace. Only suitable for files with no dependencies on the rest of
+ * the bundle or on browser globals.
+ */
+export function loadNamespaceFile(relativePath: string): Record<string, any> {
+  const js = compile(relativePath)
+  const moduleShim = { exports: {} as Record<string, any> }
+  const run = new Function("module", "exports", `${js}\nmodule.exports = ProcessOut;`)
+  run(moduleShim, moduleShim.exports)
+  return moduleShim.exports
+}


### PR DESCRIPTION
## Summary

In Dynamic Checkout, cancelling a payment on a gateway's hosted page (e.g. KCP) fired `processout_dynamic_checkout_payment_error` instead of `processout_dynamic_checkout_payment_cancelled`. Reported by Caterpillar via KCP.

## Changes

- Add `isCustomerCancellationError` helper that matches both `customer.canceled` (SDK-internal: overlay cancel, tab closed) and `customer.cancelled` (API error code returned when the customer cancels on the gateway's page)
- Use it at all 6 cancellation checks in DC payment methods (`apm`, `saved-apm`, `saved-card`, `card`), which previously only matched the SDK-internal spelling
- Add unit tests for the helper + a generic namespace-file loader in the test harness
- Bump version to 1.9.11

## Additional Context

- Root cause: tessel9 normalizes gateway-page cancels to `customer.cancelled` (two "l"s), which reaches the SDK via the checkout page's `error` action and failed the strict `customer.canceled` check
- Not KCP-specific — Klarna, RevolutPay, Xendit and others map to the same code
- `actionhandler.ts` is intentionally untouched so legacy (non-DC) integrations keep receiving the raw error code
- `tab_closed` stays correct: backend-originated cancels carry no `tab_closed` metadata, so it reports `false`